### PR TITLE
[Feat]: Spring Security를 이용한 카카오 소셜 회원 관리 기능 추가

### DIFF
--- a/src/main/java/com/dahhong/whoami/auth/adapter/in/KakaoOauthController.java
+++ b/src/main/java/com/dahhong/whoami/auth/adapter/in/KakaoOauthController.java
@@ -1,9 +1,11 @@
 package com.dahhong.whoami.auth.adapter.in;
 
 import com.dahhong.whoami.auth.adapter.in.dto.KakaoCallbackResponseDto;
+import com.dahhong.whoami.auth.application.port.in.KakaoTokenRefreshUseCase;
 import com.dahhong.whoami.auth.application.port.in.LoginKakaoUseCase;
 import com.dahhong.whoami.auth.application.port.in.LogoutKakaoUseCase;
 import com.dahhong.whoami.auth.application.port.in.QuitKakaoUseCase;
+import com.dahhong.whoami.auth.application.service.dto.TokenRefreshResponseDto;
 import com.dahhong.whoami.global.response.ApiResponse;
 import com.dahhong.whoami.user.application.port.in.QuitUserUseCase;
 import lombok.RequiredArgsConstructor;
@@ -11,10 +13,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,6 +27,8 @@ public class KakaoOauthController {
     private final QuitKakaoUseCase quitKakaoUseCase;
 
     private final QuitUserUseCase quitUserUseCase;
+
+    private final KakaoTokenRefreshUseCase kakaoTokenRefreshUseCase;
 
     @GetMapping("/login")
     public ResponseEntity<?> loginKakao() {
@@ -53,6 +54,12 @@ public class KakaoOauthController {
         String userId = quitKakaoUseCase.quitKakao(accessToken).getId();
         quitUserUseCase.quitUser(userId);
         return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<TokenRefreshResponseDto>> refresh(@RequestHeader("Refresh_Token") String refreshToken) {
+        TokenRefreshResponseDto newTokenPair = kakaoTokenRefreshUseCase.refresh(refreshToken);
+        return ResponseEntity.ok(ApiResponse.success(newTokenPair));
     }
 
 }

--- a/src/main/java/com/dahhong/whoami/auth/adapter/in/KakaoOauthController.java
+++ b/src/main/java/com/dahhong/whoami/auth/adapter/in/KakaoOauthController.java
@@ -44,13 +44,15 @@ public class KakaoOauthController {
     }
 
     @DeleteMapping("/logout")
-    public ResponseEntity<ApiResponse<String>> logout(@Param("accessToken") String accessToken) {
+    public ResponseEntity<ApiResponse<String>> logout(@RequestHeader("Authorization") String accessToken) {
+        accessToken = accessToken.replace("Bearer ", "");
         logoutKakaoUseCase.logoutKakao(accessToken);
         return ResponseEntity.ok(ApiResponse.success());
     }
 
     @DeleteMapping("/quit")
-    public ResponseEntity<ApiResponse<Void>> quit(@Param("accessToken") String accessToken) {
+    public ResponseEntity<ApiResponse<Void>> quit(@RequestHeader("Authorization") String accessToken) {
+        accessToken = accessToken.replace("Bearer ", "");
         String userId = quitKakaoUseCase.quitKakao(accessToken).getId();
         quitUserUseCase.quitUser(userId);
         return ResponseEntity.ok(ApiResponse.success());

--- a/src/main/java/com/dahhong/whoami/auth/adapter/in/KakaoOauthController.java
+++ b/src/main/java/com/dahhong/whoami/auth/adapter/in/KakaoOauthController.java
@@ -38,10 +38,7 @@ public class KakaoOauthController {
 
     @GetMapping("/callback")
     public ResponseEntity<ApiResponse<KakaoCallbackResponseDto>> callbackByKakao(@Param("code") String code) {
-        String accessToken = loginKakaoUseCase.loginKakao(code);
-        KakaoCallbackResponseDto responseDto = KakaoCallbackResponseDto.builder()
-                .accessToken(accessToken)
-                .build();
+        KakaoCallbackResponseDto responseDto = loginKakaoUseCase.loginKakao(code);
         return ResponseEntity.ok(ApiResponse.success(responseDto));
     }
 

--- a/src/main/java/com/dahhong/whoami/auth/adapter/in/dto/KakaoCallbackResponseDto.java
+++ b/src/main/java/com/dahhong/whoami/auth/adapter/in/dto/KakaoCallbackResponseDto.java
@@ -13,4 +13,6 @@ public class KakaoCallbackResponseDto {
 
     private String accessToken;
 
+    private String refreshToken;
+
 }

--- a/src/main/java/com/dahhong/whoami/auth/application/port/in/KakaoTokenRefreshUseCase.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/port/in/KakaoTokenRefreshUseCase.java
@@ -1,0 +1,9 @@
+package com.dahhong.whoami.auth.application.port.in;
+
+import com.dahhong.whoami.auth.application.service.dto.TokenRefreshResponseDto;
+
+public interface KakaoTokenRefreshUseCase {
+
+    TokenRefreshResponseDto refresh(String refreshToken);
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/port/in/LoginKakaoUseCase.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/port/in/LoginKakaoUseCase.java
@@ -1,11 +1,13 @@
 package com.dahhong.whoami.auth.application.port.in;
 
+import com.dahhong.whoami.auth.adapter.in.dto.KakaoCallbackResponseDto;
+
 import java.net.URI;
 
 public interface LoginKakaoUseCase {
 
     URI getKakaoOauthURI();
 
-    String loginKakao(String code);
+    KakaoCallbackResponseDto loginKakao(String code);
 
 }

--- a/src/main/java/com/dahhong/whoami/auth/application/service/KakaoTokenRefreshService.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/KakaoTokenRefreshService.java
@@ -1,0 +1,57 @@
+package com.dahhong.whoami.auth.application.service;
+
+import com.dahhong.whoami.auth.application.port.in.KakaoTokenRefreshUseCase;
+import com.dahhong.whoami.auth.application.service.dto.TokenRefreshResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoTokenRefreshService implements KakaoTokenRefreshUseCase {
+
+    private final RestTemplate restTemplate;
+
+    private final String ROOT_URI = "https://kapi.kakao.com";
+
+    private final String ACCESS_TOKEN_REFRESH_URL = "/oauth/token";
+
+    @Value("${kakao.client.id}")
+    private String clientID;
+
+    public TokenRefreshResponseDto refresh(String refreshToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> tokenRefreshRequestBody = new LinkedMultiValueMap<>();
+        tokenRefreshRequestBody.add("grant_type", "refresh_token");
+        tokenRefreshRequestBody.add("client_id", clientID);
+        tokenRefreshRequestBody.add("refresh_token", refreshToken);
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(tokenRefreshRequestBody, headers);
+
+        URI uri = UriComponentsBuilder
+                .fromUriString(ROOT_URI)
+                .path(ACCESS_TOKEN_REFRESH_URL)
+                .build()
+                .toUri();
+
+        try {
+            ResponseEntity<TokenRefreshResponseDto> response = restTemplate.exchange(uri, HttpMethod.POST, request, TokenRefreshResponseDto.class);
+            return response.getBody();
+        } catch (RestClientException | NullPointerException e) {
+            throw new RestClientException("토큰 재발급에 실패했습니다.");
+        }
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/service/LoginKakaoService.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/LoginKakaoService.java
@@ -1,5 +1,6 @@
 package com.dahhong.whoami.auth.application.service;
 
+import com.dahhong.whoami.auth.adapter.in.dto.KakaoCallbackResponseDto;
 import com.dahhong.whoami.auth.application.port.in.LoginKakaoUseCase;
 import com.dahhong.whoami.auth.application.port.in.LogoutKakaoUseCase;
 import com.dahhong.whoami.auth.application.service.dto.GetTokenResponseDto;
@@ -87,14 +88,17 @@ public class LoginKakaoService implements LoginKakaoUseCase {
 
     @Override
     @Transactional
-    public String loginKakao(String code) {
+    public KakaoCallbackResponseDto loginKakao(String code) {
         GetTokenResponseDto response = publishTokenByCode(code);
         String userId = idTokenService.getUserId(response.getId_token());
         UserInfoResponseDto userInfo = getKaKaoUserInfoService.getUserInfo(response.getAccess_token());
         joinKakaoUserUseCase.joinKakaoUser(userId,
                 userInfo.getKakao_account().getProfile().getNickname(),
                 userInfo.getKakao_account().getProfile().getProfile_image_url());
-        return response.getAccess_token();
+        return KakaoCallbackResponseDto.builder()
+                .accessToken(response.getAccess_token())
+                .refreshToken(response.getRefresh_token())
+                .build();
     }
 
 }

--- a/src/main/java/com/dahhong/whoami/auth/application/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/UserDetailsServiceImpl.java
@@ -1,0 +1,25 @@
+package com.dahhong.whoami.auth.application.service;
+
+import com.dahhong.whoami.auth.domain.entity.UserDetailsImpl;
+import com.dahhong.whoami.user.application.port.out.UserQueryPort;
+import com.dahhong.whoami.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserQueryPort userQueryPort;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userQueryPort.findById(username).orElseThrow(
+                () -> new UsernameNotFoundException("User Not Found with username: " + username));
+        return new UserDetailsImpl(user);
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/service/dto/TokenRefreshResponseDto.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/dto/TokenRefreshResponseDto.java
@@ -1,0 +1,26 @@
+package com.dahhong.whoami.auth.application.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TokenRefreshResponseDto {
+
+    private String token_type;
+
+    private String access_token;
+
+    private String id_token;
+
+    private Integer expires_in;
+
+    private String refresh_token;
+
+    private Integer refresh_token_expires_in;
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/domain/entity/UserDetailsImpl.java
+++ b/src/main/java/com/dahhong/whoami/auth/domain/entity/UserDetailsImpl.java
@@ -1,0 +1,33 @@
+package com.dahhong.whoami.auth.domain.entity;
+
+import com.dahhong.whoami.user.domain.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class UserDetailsImpl implements UserDetails {
+
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(user.getRole());
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getId();
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/global/config/KaKaoRestTemplateConfig.java
+++ b/src/main/java/com/dahhong/whoami/global/config/KaKaoRestTemplateConfig.java
@@ -1,4 +1,4 @@
-package com.dahhong.whoami.auth.application.service;
+package com.dahhong.whoami.global.config;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/dahhong/whoami/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dahhong/whoami/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.dahhong.whoami.global.response.enums.ResultCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -48,4 +49,13 @@ public class GlobalExceptionHandler {
             e.getMessage());
         return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
     }
+
+    @ExceptionHandler(value = UsernameNotFoundException.class)
+    public ResponseEntity<ApiResponse<Object>> usernameNotFoundExceptionHandler(Exception e) {
+        final ApiResponse<Object> response = ApiResponse.failure(ResultCode.FORBIDDEN,
+                e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.FORBIDDEN);
+    }
+
+
 }

--- a/src/main/java/com/dahhong/whoami/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dahhong/whoami/global/exception/GlobalExceptionHandler.java
@@ -1,14 +1,17 @@
 package com.dahhong.whoami.global.exception;
 
+import com.dahhong.whoami.global.exception.customException.AuthorizationFailureException;
 import com.dahhong.whoami.global.exception.customException.NotFoundException;
 import com.dahhong.whoami.global.response.ApiResponse;
 import com.dahhong.whoami.global.response.enums.ResultCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.RestClientException;
 
 @Slf4j
 @RestControllerAdvice
@@ -57,5 +60,11 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.FORBIDDEN);
     }
 
+    @ExceptionHandler(value = AuthorizationFailureException.class)
+    public ResponseEntity<ApiResponse<Object>> authorizationFailureExceptionHandler(Exception e) {
+        final ApiResponse<Object> response = ApiResponse.failure(ResultCode.UNAUTHORIZED,
+            e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
+    }
 
 }

--- a/src/main/java/com/dahhong/whoami/global/exception/customException/AuthorizationFailureException.java
+++ b/src/main/java/com/dahhong/whoami/global/exception/customException/AuthorizationFailureException.java
@@ -1,0 +1,11 @@
+package com.dahhong.whoami.global.exception.customException;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class AuthorizationFailureException extends AuthenticationException {
+
+    public AuthorizationFailureException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/global/response/enums/ResultCode.java
+++ b/src/main/java/com/dahhong/whoami/global/response/enums/ResultCode.java
@@ -10,7 +10,8 @@ public enum ResultCode {
     BAD_REQUEST("요청에 오류가 있습니다.", "400"),
     FORBIDDEN("허용되지 않은 접근입니다.", "403"),
     NOT_FOUND("대상이 존재하지 않습니다.", "404"),
-    INTERNAL_SERVER_ERROR("서버에 오류가 발생했습니다. 잠시 후 다시 시도해주세요.", "500");
+    INTERNAL_SERVER_ERROR("서버에 오류가 발생했습니다. 잠시 후 다시 시도해주세요.", "500"),
+    UNAUTHORIZED("인증에 실패했습니다.", "401");
 
     private final String message;
 

--- a/src/main/java/com/dahhong/whoami/global/security/SecurityConfig.java
+++ b/src/main/java/com/dahhong/whoami/global/security/SecurityConfig.java
@@ -1,19 +1,52 @@
 package com.dahhong.whoami.global.security;
 
+import com.dahhong.whoami.global.security.authenticationProvider.KakaoAuthenticationProvider;
+import com.dahhong.whoami.global.security.filter.KakaoJwtAuthenticationFilter;
+import com.dahhong.whoami.user.application.port.out.UserQueryPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.client.RestTemplate;
 
-@RequiredArgsConstructor
-@EnableWebSecurity
 @Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final UserQueryPort userQueryPort;
+
+    private final KakaoAuthenticationProvider kakaoAuthenticationProvider;
+
+    private final RestTemplate restTemplate;
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> web.ignoring()
+                .requestMatchers("/error", "/favicon.ico");
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorizeRequests -> authorizeRequests
+                        .requestMatchers("/api/v1/auth/kakao/login").permitAll()
+                        .requestMatchers("/api/v1/auth/kakao/callback").permitAll()
+                        .requestMatchers("/api/v1/auth/kakao/refresh").permitAll()
+                        .requestMatchers("/api/v1/auth/kakao/**").authenticated()
+                        .anyRequest().permitAll()
+                )
+                .addFilterBefore(new KakaoJwtAuthenticationFilter(userQueryPort, kakaoAuthenticationProvider, restTemplate), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 

--- a/src/main/java/com/dahhong/whoami/global/security/authenticationProvider/KakaoAuthenticationProvider.java
+++ b/src/main/java/com/dahhong/whoami/global/security/authenticationProvider/KakaoAuthenticationProvider.java
@@ -1,0 +1,31 @@
+package com.dahhong.whoami.global.security.authenticationProvider;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoAuthenticationProvider implements AuthenticationProvider {
+
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        UserDetails userDetails = userDetailsService.loadUserByUsername((String) authentication.getPrincipal());
+        return new UsernamePasswordAuthenticationToken(userDetails.getUsername(), userDetails.getPassword());
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return false;
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/global/security/filter/KakaoJwtAuthenticationFilter.java
+++ b/src/main/java/com/dahhong/whoami/global/security/filter/KakaoJwtAuthenticationFilter.java
@@ -1,0 +1,99 @@
+package com.dahhong.whoami.global.security.filter;
+
+import com.dahhong.whoami.global.security.authenticationProvider.KakaoAuthenticationProvider;
+import com.dahhong.whoami.global.security.filter.dto.AccessTokenVerificationResponseDto;
+import com.dahhong.whoami.user.application.port.out.UserQueryPort;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import net.minidev.json.JSONObject;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.filter.GenericFilterBean;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+
+@RequiredArgsConstructor
+public class KakaoJwtAuthenticationFilter extends GenericFilterBean {
+
+    private final UserQueryPort userQueryPort;
+
+    private final KakaoAuthenticationProvider kakaoAuthenticationProvider;
+
+    private final RestTemplate restTemplate;
+
+    private final String ROOT_URI = "https://kapi.kakao.com";
+
+    private final String ACCESS_TOKEN_VERIFICATION_URL = "/v1/user/access_token_info";
+
+    private boolean verification(String id) {
+        return userQueryPort.findById(id).isPresent();
+    }
+
+    private String extractUserId(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+
+        URI uri = UriComponentsBuilder
+                .fromUriString(ROOT_URI)
+                .path(ACCESS_TOKEN_VERIFICATION_URL)
+                .build()
+                .toUri();
+
+        try {
+            ResponseEntity<AccessTokenVerificationResponseDto> response = restTemplate.exchange(uri, HttpMethod.GET, request, AccessTokenVerificationResponseDto.class);
+            return response.getBody().getId().toString();
+        } catch (RestClientException | NullPointerException e) {
+            System.out.println(e.getMessage());
+            throw new RestClientException("카카오 서버에서 유저 토큰을 인증하는 것에 실패했습니다.");
+        }
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        Authentication authenticate;
+
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+        String accessToken = request.getHeader("Authorization") != null ? request.getHeader("Authorization").substring(7) : null;
+
+        // 엑세스 토큰이 NULL일 경우 다음 필터에서 인증의 책임을 가진다
+        if (accessToken == null) {
+            filterChain.doFilter(servletRequest, servletResponse);
+            return;
+        }
+
+        String userId = extractUserId(accessToken);
+        if (verification(userId)) {
+            try {
+                authenticate = kakaoAuthenticationProvider.authenticate(new UsernamePasswordAuthenticationToken(userId, ""));
+                SecurityContextHolder.getContext().setAuthentication(authenticate);
+            } catch(Exception e) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json");
+                response.setCharacterEncoding("UTF-8");
+
+                JSONObject resJson = new JSONObject();
+                resJson.put("code", 401);
+                resJson.put("message", e.getMessage());
+
+                response.getWriter().write(resJson.toString());
+            }
+        }
+
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/global/security/filter/KakaoJwtAuthenticationFilter.java
+++ b/src/main/java/com/dahhong/whoami/global/security/filter/KakaoJwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.dahhong.whoami.global.security.filter;
 
+import com.dahhong.whoami.global.exception.customException.AuthorizationFailureException;
 import com.dahhong.whoami.global.security.authenticationProvider.KakaoAuthenticationProvider;
 import com.dahhong.whoami.global.security.filter.dto.AccessTokenVerificationResponseDto;
 import com.dahhong.whoami.user.application.port.out.UserQueryPort;
@@ -14,6 +15,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClientException;
@@ -56,8 +58,7 @@ public class KakaoJwtAuthenticationFilter extends GenericFilterBean {
             ResponseEntity<AccessTokenVerificationResponseDto> response = restTemplate.exchange(uri, HttpMethod.GET, request, AccessTokenVerificationResponseDto.class);
             return response.getBody().getId().toString();
         } catch (RestClientException | NullPointerException e) {
-            System.out.println(e.getMessage());
-            throw new RestClientException("카카오 서버에서 유저 토큰을 인증하는 것에 실패했습니다.");
+            throw new AuthorizationFailureException("카카오 서버에서 유저 토큰을 인증하는 것에 실패했습니다.", e.getCause());
         }
     }
 

--- a/src/main/java/com/dahhong/whoami/global/security/filter/dto/AccessTokenVerificationResponseDto.java
+++ b/src/main/java/com/dahhong/whoami/global/security/filter/dto/AccessTokenVerificationResponseDto.java
@@ -1,0 +1,20 @@
+package com.dahhong.whoami.global.security.filter.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AccessTokenVerificationResponseDto {
+
+    private Long id;
+
+    private Integer expires_in;
+
+    private Integer app_id;
+
+}

--- a/src/main/java/com/dahhong/whoami/user/application/service/JoinKakaoUserService.java
+++ b/src/main/java/com/dahhong/whoami/user/application/service/JoinKakaoUserService.java
@@ -4,6 +4,7 @@ import com.dahhong.whoami.user.application.port.in.GetUserUseCase;
 import com.dahhong.whoami.user.application.port.in.JoinKakaoUserUseCase;
 import com.dahhong.whoami.user.application.port.out.UserCommandPort;
 import com.dahhong.whoami.user.domain.entity.AuthType;
+import com.dahhong.whoami.user.domain.entity.Role;
 import com.dahhong.whoami.user.domain.entity.User;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +24,7 @@ public class JoinKakaoUserService implements JoinKakaoUserUseCase {
         if (getUserUseCase.isExistUser(id)) {
             return;
         }
-        User user = User.of(id, AuthType.KAKAO, nickname, profileImage);
+        User user = User.of(id, Role.USER, AuthType.KAKAO, nickname, profileImage);
         userCommandPort.save(user);
     }
 

--- a/src/main/java/com/dahhong/whoami/user/domain/entity/Role.java
+++ b/src/main/java/com/dahhong/whoami/user/domain/entity/Role.java
@@ -1,0 +1,13 @@
+package com.dahhong.whoami.user.domain.entity;
+
+import org.springframework.security.core.GrantedAuthority;
+
+public enum Role implements GrantedAuthority {
+    USER, ADMIN;
+
+    @Override
+    public String getAuthority() {
+        return name();
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/user/domain/entity/User.java
+++ b/src/main/java/com/dahhong/whoami/user/domain/entity/User.java
@@ -16,6 +16,9 @@ public class User {
     private String id;
 
     @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Enumerated(EnumType.STRING)
     private AuthType authType;
 
     @Column(length = 100)
@@ -24,8 +27,8 @@ public class User {
     @Column(length = 1000)
     private String profilePicture;
 
-    public static User of(String id, AuthType authType, String name, String profilePicture) {
-        return new User(id, authType, name, profilePicture);
+    public static User of(String id, Role role, AuthType authType, String name, String profilePicture) {
+        return new User(id, role, authType, name, profilePicture);
     }
 
 }


### PR DESCRIPTION
## 요약
Spring Security를 이용하여 Security 서블릿 컨테이너에서 자체적으로 Authority를 관리하는 기능 구현

## 상세
- 카카오 로그인을 통한 스프링 시큐리티 인증 기능 추가
- AccessToken 헤더가 아니라 Authorization 헤더를 이용하여 AccessToken을 관리하게 변경
- 토큰 인증 실패 커스텀 예외 추가