### PR TITLE
[Feat]: Kakao를 이용한 서비스 인증/인가 로직&문서화 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/dahhong/whoami/auth/adapter/in/KakaoOauthController.java
+++ b/src/main/java/com/dahhong/whoami/auth/adapter/in/KakaoOauthController.java
@@ -1,12 +1,17 @@
 package com.dahhong.whoami.auth.adapter.in;
 
+import com.dahhong.whoami.auth.adapter.in.dto.KakaoCallbackResponseDto;
 import com.dahhong.whoami.auth.application.port.in.LoginKakaoUseCase;
+import com.dahhong.whoami.auth.application.port.in.LogoutKakaoUseCase;
+import com.dahhong.whoami.auth.application.port.in.QuitKakaoUseCase;
 import com.dahhong.whoami.global.response.ApiResponse;
+import com.dahhong.whoami.user.application.port.in.QuitUserUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.repository.query.Param;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,6 +23,12 @@ public class KakaoOauthController {
 
     private final LoginKakaoUseCase loginKakaoUseCase;
 
+    private final LogoutKakaoUseCase logoutKakaoUseCase;
+
+    private final QuitKakaoUseCase quitKakaoUseCase;
+
+    private final QuitUserUseCase quitUserUseCase;
+
     @GetMapping("/login")
     public ResponseEntity<?> loginKakao() {
         HttpHeaders headers = new HttpHeaders();
@@ -25,11 +36,25 @@ public class KakaoOauthController {
         return new ResponseEntity<>(headers, HttpStatus.MOVED_PERMANENTLY);
     }
 
-
     @GetMapping("/callback")
-    public ResponseEntity<ApiResponse<Void>> callbackByKakao(@Param("code") String code) {
-        System.out.println("code = " + code);
-        loginKakaoUseCase.loginKakao(code);
+    public ResponseEntity<ApiResponse<KakaoCallbackResponseDto>> callbackByKakao(@Param("code") String code) {
+        String accessToken = loginKakaoUseCase.loginKakao(code);
+        KakaoCallbackResponseDto responseDto = KakaoCallbackResponseDto.builder()
+                .accessToken(accessToken)
+                .build();
+        return ResponseEntity.ok(ApiResponse.success(responseDto));
+    }
+
+    @DeleteMapping("/logout")
+    public ResponseEntity<ApiResponse<String>> logout(@Param("accessToken") String accessToken) {
+        logoutKakaoUseCase.logoutKakao(accessToken);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @DeleteMapping("/quit")
+    public ResponseEntity<ApiResponse<Void>> quit(@Param("accessToken") String accessToken) {
+        String userId = quitKakaoUseCase.quitKakao(accessToken).getId();
+        quitUserUseCase.quitUser(userId);
         return ResponseEntity.ok(ApiResponse.success());
     }
 

--- a/src/main/java/com/dahhong/whoami/auth/adapter/in/KakaoOauthController.java
+++ b/src/main/java/com/dahhong/whoami/auth/adapter/in/KakaoOauthController.java
@@ -1,6 +1,7 @@
 package com.dahhong.whoami.auth.adapter.in;
 
 import com.dahhong.whoami.auth.adapter.in.dto.KakaoCallbackResponseDto;
+import com.dahhong.whoami.auth.adapter.in.swagger.KakaoOauthControllerSwagger;
 import com.dahhong.whoami.auth.application.port.in.KakaoTokenRefreshUseCase;
 import com.dahhong.whoami.auth.application.port.in.LoginKakaoUseCase;
 import com.dahhong.whoami.auth.application.port.in.LogoutKakaoUseCase;
@@ -18,7 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth/kakao")
-public class KakaoOauthController {
+public class KakaoOauthController implements KakaoOauthControllerSwagger {
 
     private final LoginKakaoUseCase loginKakaoUseCase;
 

--- a/src/main/java/com/dahhong/whoami/auth/adapter/in/KakaoOauthController.java
+++ b/src/main/java/com/dahhong/whoami/auth/adapter/in/KakaoOauthController.java
@@ -1,9 +1,11 @@
 package com.dahhong.whoami.auth.adapter.in;
 
 import com.dahhong.whoami.auth.adapter.in.dto.KakaoCallbackResponseDto;
+import com.dahhong.whoami.auth.application.port.in.KakaoTokenRefreshUseCase;
 import com.dahhong.whoami.auth.application.port.in.LoginKakaoUseCase;
 import com.dahhong.whoami.auth.application.port.in.LogoutKakaoUseCase;
 import com.dahhong.whoami.auth.application.port.in.QuitKakaoUseCase;
+import com.dahhong.whoami.auth.application.service.dto.TokenRefreshResponseDto;
 import com.dahhong.whoami.global.response.ApiResponse;
 import com.dahhong.whoami.user.application.port.in.QuitUserUseCase;
 import lombok.RequiredArgsConstructor;
@@ -11,10 +13,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,6 +28,8 @@ public class KakaoOauthController {
 
     private final QuitUserUseCase quitUserUseCase;
 
+    private final KakaoTokenRefreshUseCase kakaoTokenRefreshUseCase;
+
     @GetMapping("/login")
     public ResponseEntity<?> loginKakao() {
         HttpHeaders headers = new HttpHeaders();
@@ -38,24 +39,29 @@ public class KakaoOauthController {
 
     @GetMapping("/callback")
     public ResponseEntity<ApiResponse<KakaoCallbackResponseDto>> callbackByKakao(@Param("code") String code) {
-        String accessToken = loginKakaoUseCase.loginKakao(code);
-        KakaoCallbackResponseDto responseDto = KakaoCallbackResponseDto.builder()
-                .accessToken(accessToken)
-                .build();
+        KakaoCallbackResponseDto responseDto = loginKakaoUseCase.loginKakao(code);
         return ResponseEntity.ok(ApiResponse.success(responseDto));
     }
 
     @DeleteMapping("/logout")
-    public ResponseEntity<ApiResponse<String>> logout(@Param("accessToken") String accessToken) {
+    public ResponseEntity<ApiResponse<String>> logout(@RequestHeader("Authorization") String accessToken) {
+        accessToken = accessToken.replace("Bearer ", "");
         logoutKakaoUseCase.logoutKakao(accessToken);
         return ResponseEntity.ok(ApiResponse.success());
     }
 
     @DeleteMapping("/quit")
-    public ResponseEntity<ApiResponse<Void>> quit(@Param("accessToken") String accessToken) {
+    public ResponseEntity<ApiResponse<Void>> quit(@RequestHeader("Authorization") String accessToken) {
+        accessToken = accessToken.replace("Bearer ", "");
         String userId = quitKakaoUseCase.quitKakao(accessToken).getId();
         quitUserUseCase.quitUser(userId);
         return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<TokenRefreshResponseDto>> refresh(@RequestHeader("Refresh_Token") String refreshToken) {
+        TokenRefreshResponseDto newTokenPair = kakaoTokenRefreshUseCase.refresh(refreshToken);
+        return ResponseEntity.ok(ApiResponse.success(newTokenPair));
     }
 
 }

--- a/src/main/java/com/dahhong/whoami/auth/adapter/in/KakaoOauthController.java
+++ b/src/main/java/com/dahhong/whoami/auth/adapter/in/KakaoOauthController.java
@@ -1,0 +1,36 @@
+package com.dahhong.whoami.auth.adapter.in;
+
+import com.dahhong.whoami.auth.application.port.in.LoginKakaoUseCase;
+import com.dahhong.whoami.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.query.Param;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth/kakao")
+public class KakaoOauthController {
+
+    private final LoginKakaoUseCase loginKakaoUseCase;
+
+    @GetMapping("/login")
+    public ResponseEntity<?> loginKakao() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(loginKakaoUseCase.getKakaoOauthURI());
+        return new ResponseEntity<>(headers, HttpStatus.MOVED_PERMANENTLY);
+    }
+
+
+    @GetMapping("/callback")
+    public ResponseEntity<ApiResponse<Void>> callbackByKakao(@Param("code") String code) {
+        System.out.println("code = " + code);
+        loginKakaoUseCase.loginKakao(code);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/adapter/in/dto/KakaoCallbackResponseDto.java
+++ b/src/main/java/com/dahhong/whoami/auth/adapter/in/dto/KakaoCallbackResponseDto.java
@@ -13,4 +13,6 @@ public class KakaoCallbackResponseDto {
 
     private String accessToken;
 
+    private String refreshToken;
+
 }

--- a/src/main/java/com/dahhong/whoami/auth/adapter/in/dto/KakaoCallbackResponseDto.java
+++ b/src/main/java/com/dahhong/whoami/auth/adapter/in/dto/KakaoCallbackResponseDto.java
@@ -1,0 +1,16 @@
+package com.dahhong.whoami.auth.adapter.in.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class KakaoCallbackResponseDto {
+
+    private String accessToken;
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/adapter/in/swagger/KakaoOauthControllerSwagger.java
+++ b/src/main/java/com/dahhong/whoami/auth/adapter/in/swagger/KakaoOauthControllerSwagger.java
@@ -1,0 +1,38 @@
+package com.dahhong.whoami.auth.adapter.in.swagger;
+
+import com.dahhong.whoami.auth.adapter.in.dto.KakaoCallbackResponseDto;
+import com.dahhong.whoami.auth.application.service.dto.TokenRefreshResponseDto;
+import com.dahhong.whoami.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+public interface KakaoOauthControllerSwagger {
+
+    @Tag(name = "카카오 로그인/회원가입", description = "카카오 로그인/회원가입")
+    @Operation(summary = "카카오 로그인/회원가입", description = "카카오 OAuth2를 통해 로그인/회원가입(통합)을 시도합니다.\n카카오 인증 페이지로 리다이렉션 됩니다.")
+    ResponseEntity<?> loginKakao();
+
+    @Tag(name = "카카오 로그인/회원가입", description = "카카오 로그인 콜백")
+    @Operation(summary = "카카오 로그인 콜백", description = "카카오 OAuth2 정보 동의를 마무리 한 뒤, 리다이렉트 되는 콜백 URL 입니다.")
+    @Parameters({
+            @Parameter(name = "code", description = "카카오 정보 동의시에 자동으로 발급되는 Code 값 (일반적으로 직접 넣어줄 필요가 없습니다.)", required = true)
+    })
+    ResponseEntity<ApiResponse<KakaoCallbackResponseDto>> callbackByKakao(String code);
+
+    @Tag(name = "카카오 로그아웃/회원탈퇴", description = "카카오 로그아웃")
+    @Operation(summary = "카카오 로그아웃", description = "카카오 OAuth2를 통해 로그인한 사용자를 로그아웃 합니다.")
+    ResponseEntity<ApiResponse<String>> logout(String accessToken);
+
+    @Tag(name = "카카오 로그아웃/회원탈퇴", description = "카카오 회원탈퇴")
+    @Operation(summary = "카카오 회원탈퇴", description = "카카오 OAuth2를 통해 회원가입한 사용자를 회원탈퇴 합니다.")
+    ResponseEntity<ApiResponse<Void>> quit(String accessToken);
+
+    @Tag(name = "카카오 JWT 토큰 갱신", description = "카카오 토큰 갱신")
+    @Operation(summary = "카카오 토큰 갱신", description = "카카오 OAuth2를 통해 로그인한 사용자의 토큰을 Refresh Token을 사용해 갱신합니다.")
+    ResponseEntity<ApiResponse<TokenRefreshResponseDto>> refresh(String refreshToken);
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/port/in/KakaoTokenRefreshUseCase.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/port/in/KakaoTokenRefreshUseCase.java
@@ -1,0 +1,9 @@
+package com.dahhong.whoami.auth.application.port.in;
+
+import com.dahhong.whoami.auth.application.service.dto.TokenRefreshResponseDto;
+
+public interface KakaoTokenRefreshUseCase {
+
+    TokenRefreshResponseDto refresh(String refreshToken);
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/port/in/LoginKakaoUseCase.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/port/in/LoginKakaoUseCase.java
@@ -6,6 +6,6 @@ public interface LoginKakaoUseCase {
 
     URI getKakaoOauthURI();
 
-    void loginKakao(String code);
+    String loginKakao(String code);
 
 }

--- a/src/main/java/com/dahhong/whoami/auth/application/port/in/LoginKakaoUseCase.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/port/in/LoginKakaoUseCase.java
@@ -1,11 +1,13 @@
 package com.dahhong.whoami.auth.application.port.in;
 
+import com.dahhong.whoami.auth.adapter.in.dto.KakaoCallbackResponseDto;
+
 import java.net.URI;
 
 public interface LoginKakaoUseCase {
 
     URI getKakaoOauthURI();
 
-    String loginKakao(String code);
+    KakaoCallbackResponseDto loginKakao(String code);
 
 }

--- a/src/main/java/com/dahhong/whoami/auth/application/port/in/LoginKakaoUseCase.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/port/in/LoginKakaoUseCase.java
@@ -1,0 +1,11 @@
+package com.dahhong.whoami.auth.application.port.in;
+
+import java.net.URI;
+
+public interface LoginKakaoUseCase {
+
+    URI getKakaoOauthURI();
+
+    void loginKakao(String code);
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/port/in/LogoutKakaoUseCase.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/port/in/LogoutKakaoUseCase.java
@@ -1,0 +1,7 @@
+package com.dahhong.whoami.auth.application.port.in;
+
+public interface LogoutKakaoUseCase {
+
+    void logoutKakao(String accessToken);
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/port/in/QuitKakaoUseCase.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/port/in/QuitKakaoUseCase.java
@@ -1,0 +1,9 @@
+package com.dahhong.whoami.auth.application.port.in;
+
+import com.dahhong.whoami.auth.application.service.dto.QuitKakaoResponseDto;
+
+public interface QuitKakaoUseCase {
+
+    QuitKakaoResponseDto quitKakao(String accessToken);
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/service/GetKaKaoUserInfoService.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/GetKaKaoUserInfoService.java
@@ -1,0 +1,50 @@
+package com.dahhong.whoami.auth.application.service;
+
+import com.dahhong.whoami.auth.application.service.dto.UserInfoResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Service
+@RequiredArgsConstructor
+public class GetKaKaoUserInfoService {
+
+    private final RestTemplate restTemplate;
+
+    private final String ROOT_URI = "https://kapi.kakao.com";
+
+    private final String USER_INFO_URL = "/v2/user/me";
+
+    public UserInfoResponseDto getUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        headers.set("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+
+        URI uri = UriComponentsBuilder
+                .fromUriString(ROOT_URI)
+                .path(USER_INFO_URL)
+                .queryParam("secure_resource", true)
+                .queryParam("property_keys", "[\"kakao_account.profile\"]")
+                .build()
+                .toUri();
+
+        try {
+            ResponseEntity<UserInfoResponseDto> response = restTemplate.exchange(uri, HttpMethod.GET, request, UserInfoResponseDto.class);
+            return response.getBody();
+        } catch (RestClientException e) {
+            System.out.println(e.getMessage());
+            throw new RestClientException("카카오 서버에서 유저 정보를 받아오는 것에 실패했습니다.");
+        }
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/service/IdTokenService.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/IdTokenService.java
@@ -1,0 +1,56 @@
+package com.dahhong.whoami.auth.application.service;
+
+import com.dahhong.whoami.auth.application.service.dto.IdTokenPayloadResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Service
+@RequiredArgsConstructor
+public class IdTokenService {
+
+    private final RestTemplate restTemplate;
+
+    private final String ROOT_URI = "https://kauth.kakao.com";
+
+    private final String TOKEN_INFO_URL = "/oauth/tokeninfo";
+
+    private IdTokenPayloadResponseDto getIdTokenPayload(String idToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> idTokenRequestBody = new LinkedMultiValueMap<>();
+        idTokenRequestBody.add("id_token", idToken);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(idTokenRequestBody, headers);
+
+        URI uri = UriComponentsBuilder
+                .fromUriString(ROOT_URI)
+                .path(TOKEN_INFO_URL)
+                .build()
+                .toUri();
+
+        try {
+            ResponseEntity<IdTokenPayloadResponseDto> response = restTemplate.postForEntity(uri, request, IdTokenPayloadResponseDto.class);
+            return response.getBody();
+        } catch (RestClientException e) {
+            System.out.println(e.getMessage());
+            throw new RestClientException("카카오 서버에서 유저의 고유 ID를 받아오는 것에 실패했습니다.");
+        }
+    }
+
+    public String getUserId(String idToken) {
+        IdTokenPayloadResponseDto idTokenPayload = getIdTokenPayload(idToken);
+        return idTokenPayload.getSub();
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/service/KaKaoRestTemplateConfig.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/KaKaoRestTemplateConfig.java
@@ -1,0 +1,20 @@
+package com.dahhong.whoami.auth.application.service;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class KaKaoRestTemplateConfig {
+
+    private final String ROOT_URI = "https://kauth.kakao.com";
+
+    @Bean
+    public RestTemplate kakaoRestTemplate(RestTemplateBuilder builder) {
+        return builder
+                .rootUri(ROOT_URI)
+                .build();
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/service/KakaoTokenRefreshService.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/KakaoTokenRefreshService.java
@@ -1,0 +1,57 @@
+package com.dahhong.whoami.auth.application.service;
+
+import com.dahhong.whoami.auth.application.port.in.KakaoTokenRefreshUseCase;
+import com.dahhong.whoami.auth.application.service.dto.TokenRefreshResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoTokenRefreshService implements KakaoTokenRefreshUseCase {
+
+    private final RestTemplate restTemplate;
+
+    private final String ROOT_URI = "https://kapi.kakao.com";
+
+    private final String ACCESS_TOKEN_REFRESH_URL = "/oauth/token";
+
+    @Value("${kakao.client.id}")
+    private String clientID;
+
+    public TokenRefreshResponseDto refresh(String refreshToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> tokenRefreshRequestBody = new LinkedMultiValueMap<>();
+        tokenRefreshRequestBody.add("grant_type", "refresh_token");
+        tokenRefreshRequestBody.add("client_id", clientID);
+        tokenRefreshRequestBody.add("refresh_token", refreshToken);
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(tokenRefreshRequestBody, headers);
+
+        URI uri = UriComponentsBuilder
+                .fromUriString(ROOT_URI)
+                .path(ACCESS_TOKEN_REFRESH_URL)
+                .build()
+                .toUri();
+
+        try {
+            ResponseEntity<TokenRefreshResponseDto> response = restTemplate.exchange(uri, HttpMethod.POST, request, TokenRefreshResponseDto.class);
+            return response.getBody();
+        } catch (RestClientException | NullPointerException e) {
+            throw new RestClientException("토큰 재발급에 실패했습니다.");
+        }
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/service/LoginKakaoService.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/LoginKakaoService.java
@@ -1,5 +1,6 @@
 package com.dahhong.whoami.auth.application.service;
 
+import com.dahhong.whoami.auth.adapter.in.dto.KakaoCallbackResponseDto;
 import com.dahhong.whoami.auth.application.port.in.LoginKakaoUseCase;
 import com.dahhong.whoami.auth.application.port.in.LogoutKakaoUseCase;
 import com.dahhong.whoami.auth.application.service.dto.GetTokenResponseDto;
@@ -87,14 +88,17 @@ public class LoginKakaoService implements LoginKakaoUseCase {
 
     @Override
     @Transactional
-    public String loginKakao(String code) {
+    public KakaoCallbackResponseDto loginKakao(String code) {
         GetTokenResponseDto response = publishTokenByCode(code);
         String userId = idTokenService.getUserId(response.getId_token());
         UserInfoResponseDto userInfo = getKaKaoUserInfoService.getUserInfo(response.getAccess_token());
         joinKakaoUserUseCase.joinKakaoUser(userId,
                 userInfo.getKakao_account().getProfile().getNickname(),
                 userInfo.getKakao_account().getProfile().getProfile_image_url());
-        return response.getAccess_token();
+        return KakaoCallbackResponseDto.builder()
+                .accessToken(response.getAccess_token())
+                .refreshToken(response.getRefresh_token())
+                .build();
     }
 
 }

--- a/src/main/java/com/dahhong/whoami/auth/application/service/LoginKakaoService.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/LoginKakaoService.java
@@ -1,0 +1,96 @@
+package com.dahhong.whoami.auth.application.service;
+
+import com.dahhong.whoami.auth.application.port.in.LoginKakaoUseCase;
+import com.dahhong.whoami.auth.application.service.dto.GetTokenResponseDto;
+import com.dahhong.whoami.auth.application.service.dto.UserInfoResponseDto;
+import com.dahhong.whoami.user.application.port.in.JoinKakaoUserUseCase;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Service
+@RequiredArgsConstructor
+public class LoginKakaoService implements LoginKakaoUseCase {
+
+    private final RestTemplate restTemplate;
+
+    private final IdTokenService idTokenService;
+
+    private final GetKaKaoUserInfoService getKaKaoUserInfoService;
+
+    private final JoinKakaoUserUseCase joinKakaoUserUseCase;
+
+    private final String ROOT_URI = "https://kauth.kakao.com";
+
+    private final String AUTHORIZE_URL = "/oauth/authorize";
+
+    private final String TOKEN_URL = "/oauth/token";
+
+    @Value("${kakao.client.id}")
+    private String clientID;
+
+    @Value("${kakao.redirect.uri}")
+    private String redirectURI;
+
+    private GetTokenResponseDto publishTokenByCode(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> tokenRequestBody = new LinkedMultiValueMap<>();
+        tokenRequestBody.add("grant_type", "authorization_code");
+        tokenRequestBody.add("client_id", clientID);
+        tokenRequestBody.add("redirect_uri", redirectURI);
+        tokenRequestBody.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(tokenRequestBody, headers);
+
+        URI uri = UriComponentsBuilder
+                .fromUriString(ROOT_URI)
+                .path(TOKEN_URL)
+                .build()
+                .toUri();
+
+        try {
+            ResponseEntity<GetTokenResponseDto> response = restTemplate.postForEntity(uri, request, GetTokenResponseDto.class);
+            return response.getBody();
+        } catch (RestClientException e) {
+            System.out.println(e.getMessage());
+            throw new RestClientException("카카오 서버에서 토큰을 받아오는 것에 실패했습니다.");
+        }
+    }
+
+    @Override
+    public URI getKakaoOauthURI() {
+        return UriComponentsBuilder
+                .fromUriString(ROOT_URI)
+                .path(AUTHORIZE_URL)
+                .queryParam("client_id", clientID)
+                .queryParam("redirect_uri", redirectURI)
+                .queryParam("response_type", "code")
+                .build()
+                .toUri();
+    }
+
+    @Override
+    @Transactional
+    public void loginKakao(String code) {
+        GetTokenResponseDto response = publishTokenByCode(code);
+        String userId = idTokenService.getUserId(response.getId_token());
+        UserInfoResponseDto userInfo = getKaKaoUserInfoService.getUserInfo(response.getAccess_token());
+        joinKakaoUserUseCase.joinKakaoUser(userId,
+                userInfo.getKakao_account().getProfile().getNickname(),
+                userInfo.getKakao_account().getProfile().getProfile_image_url());
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/service/LoginKakaoService.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/LoginKakaoService.java
@@ -1,6 +1,7 @@
 package com.dahhong.whoami.auth.application.service;
 
 import com.dahhong.whoami.auth.application.port.in.LoginKakaoUseCase;
+import com.dahhong.whoami.auth.application.port.in.LogoutKakaoUseCase;
 import com.dahhong.whoami.auth.application.service.dto.GetTokenResponseDto;
 import com.dahhong.whoami.auth.application.service.dto.UserInfoResponseDto;
 import com.dahhong.whoami.user.application.port.in.JoinKakaoUserUseCase;
@@ -28,6 +29,8 @@ public class LoginKakaoService implements LoginKakaoUseCase {
     private final IdTokenService idTokenService;
 
     private final GetKaKaoUserInfoService getKaKaoUserInfoService;
+
+    private final LogoutKakaoUseCase logoutKakaoUseCase;
 
     private final JoinKakaoUserUseCase joinKakaoUserUseCase;
 
@@ -84,13 +87,14 @@ public class LoginKakaoService implements LoginKakaoUseCase {
 
     @Override
     @Transactional
-    public void loginKakao(String code) {
+    public String loginKakao(String code) {
         GetTokenResponseDto response = publishTokenByCode(code);
         String userId = idTokenService.getUserId(response.getId_token());
         UserInfoResponseDto userInfo = getKaKaoUserInfoService.getUserInfo(response.getAccess_token());
         joinKakaoUserUseCase.joinKakaoUser(userId,
                 userInfo.getKakao_account().getProfile().getNickname(),
                 userInfo.getKakao_account().getProfile().getProfile_image_url());
+        return response.getAccess_token();
     }
 
 }

--- a/src/main/java/com/dahhong/whoami/auth/application/service/LogoutKakaoService.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/LogoutKakaoService.java
@@ -1,0 +1,51 @@
+package com.dahhong.whoami.auth.application.service;
+
+import com.dahhong.whoami.auth.application.port.in.LogoutKakaoUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Service
+@RequiredArgsConstructor
+public class LogoutKakaoService implements LogoutKakaoUseCase {
+
+    private final RestTemplate restTemplate;
+
+    private final String ROOT_URI = "https://kapi.kakao.com";
+
+    private final String LOGOUT_URL = "/v1/user/logout";
+
+    @Override
+    public void logoutKakao(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+
+        URI uri = UriComponentsBuilder
+                .fromUriString(ROOT_URI)
+                .path(LOGOUT_URL)
+                .build()
+                .toUri();
+
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(uri, request, String.class);
+            if (response.getStatusCode() != HttpStatus.OK) {
+                throw new RestClientException("카카오 서버의 로그아웃 요청에 실패했습니다.");
+            }
+        } catch (RestClientException e) {
+            System.out.println(e.getMessage());
+            throw new RestClientException("카카오 서버의 로그아웃 요청에 실패했습니다.");
+        }
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/service/QuitKakaoService.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/QuitKakaoService.java
@@ -1,0 +1,53 @@
+package com.dahhong.whoami.auth.application.service;
+
+import com.dahhong.whoami.auth.application.port.in.QuitKakaoUseCase;
+import com.dahhong.whoami.auth.application.service.dto.QuitKakaoResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Service
+@RequiredArgsConstructor
+public class QuitKakaoService implements QuitKakaoUseCase {
+
+    private final RestTemplate restTemplate;
+
+    private final String ROOT_URI = "https://kapi.kakao.com";
+
+    private final String UNLINK_URL = "/v1/user/unlink";
+
+    @Override
+    public QuitKakaoResponseDto quitKakao(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+
+        URI uri = UriComponentsBuilder
+                .fromUriString(ROOT_URI)
+                .path(UNLINK_URL)
+                .build()
+                .toUri();
+
+        try {
+            ResponseEntity<QuitKakaoResponseDto> response = restTemplate.postForEntity(uri, request, QuitKakaoResponseDto.class);
+            if (response.getStatusCode() != HttpStatus.OK) {
+                throw new RestClientException("카카오 서버의 회원 탈퇴 요청에 실패했습니다.");
+            }
+            return response.getBody();
+        } catch (RestClientException e) {
+            System.out.println(e.getMessage());
+            throw new RestClientException("카카오 서버의 회원 탈퇴 요청에 실패했습니다.");
+        }
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/UserDetailsServiceImpl.java
@@ -1,0 +1,25 @@
+package com.dahhong.whoami.auth.application.service;
+
+import com.dahhong.whoami.auth.domain.entity.UserDetailsImpl;
+import com.dahhong.whoami.user.application.port.out.UserQueryPort;
+import com.dahhong.whoami.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserQueryPort userQueryPort;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userQueryPort.findById(username).orElseThrow(
+                () -> new UsernameNotFoundException("User Not Found with username: " + username));
+        return new UserDetailsImpl(user);
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/service/dto/GetTokenResponseDto.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/dto/GetTokenResponseDto.java
@@ -1,0 +1,26 @@
+package com.dahhong.whoami.auth.application.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetTokenResponseDto {
+
+    private String token_type;
+
+    private String access_token;
+
+    private String id_token;
+
+    private Integer expires_in;
+
+    private String refresh_token;
+
+    private String refresh_token_expires_in;
+
+    private String scope;
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/service/dto/IdTokenPayloadResponseDto.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/dto/IdTokenPayloadResponseDto.java
@@ -1,0 +1,26 @@
+package com.dahhong.whoami.auth.application.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class IdTokenPayloadResponseDto {
+
+    private String iss;
+
+    private String aud;
+
+    private String sub;
+
+    private Integer iat;
+
+    private Integer exp;
+
+    private String nonce;
+
+    private Integer auth_time;
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/service/dto/KakaoAccount.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/dto/KakaoAccount.java
@@ -1,0 +1,20 @@
+package com.dahhong.whoami.auth.application.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class KakaoAccount {
+
+    private Boolean profile_needs_agreement;
+
+    private Boolean profile_nickname_needs_agreement;
+
+    private Boolean profile_image_needs_agreement;
+
+    private Profile profile;
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/service/dto/Profile.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/dto/Profile.java
@@ -1,0 +1,22 @@
+package com.dahhong.whoami.auth.application.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Profile {
+
+    private String nickname;
+
+    private String thumbnail_image_url;
+
+    private String profile_image_url;
+
+    private Boolean is_default_image;
+
+    private Boolean is_default_nickname;
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/service/dto/QuitKakaoResponseDto.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/dto/QuitKakaoResponseDto.java
@@ -1,0 +1,14 @@
+package com.dahhong.whoami.auth.application.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class QuitKakaoResponseDto {
+
+    private String id;
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/service/dto/TokenRefreshResponseDto.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/dto/TokenRefreshResponseDto.java
@@ -1,0 +1,26 @@
+package com.dahhong.whoami.auth.application.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TokenRefreshResponseDto {
+
+    private String token_type;
+
+    private String access_token;
+
+    private String id_token;
+
+    private Integer expires_in;
+
+    private String refresh_token;
+
+    private Integer refresh_token_expires_in;
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/service/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/dto/UserInfoResponseDto.java
@@ -1,0 +1,16 @@
+package com.dahhong.whoami.auth.application.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserInfoResponseDto {
+
+    private Long id;
+
+    private KakaoAccount kakao_account;
+
+}

--- a/src/main/java/com/dahhong/whoami/auth/domain/entity/UserDetailsImpl.java
+++ b/src/main/java/com/dahhong/whoami/auth/domain/entity/UserDetailsImpl.java
@@ -1,0 +1,33 @@
+package com.dahhong.whoami.auth.domain.entity;
+
+import com.dahhong.whoami.user.domain.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class UserDetailsImpl implements UserDetails {
+
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(user.getRole());
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getId();
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/global/config/KaKaoRestTemplateConfig.java
+++ b/src/main/java/com/dahhong/whoami/global/config/KaKaoRestTemplateConfig.java
@@ -1,4 +1,4 @@
-package com.dahhong.whoami.auth.application.service;
+package com.dahhong.whoami.global.config;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/dahhong/whoami/global/config/SwaggerConfig.java
+++ b/src/main/java/com/dahhong/whoami/global/config/SwaggerConfig.java
@@ -1,0 +1,26 @@
+package com.dahhong.whoami.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    private Info apiInfo() {
+        return new Info()
+                .title("후엠아이 API 공식 문서")
+                .description("WHO AM I 서비스에 대한 REST API 공식 문서입니다.")
+                .version("1.0.0");
+    }
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dahhong/whoami/global/exception/GlobalExceptionHandler.java
@@ -1,13 +1,17 @@
 package com.dahhong.whoami.global.exception;
 
+import com.dahhong.whoami.global.exception.customException.AuthorizationFailureException;
 import com.dahhong.whoami.global.exception.customException.NotFoundException;
 import com.dahhong.whoami.global.response.ApiResponse;
 import com.dahhong.whoami.global.response.enums.ResultCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.RestClientException;
 
 @Slf4j
 @RestControllerAdvice
@@ -48,4 +52,19 @@ public class GlobalExceptionHandler {
             e.getMessage());
         return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
     }
+
+    @ExceptionHandler(value = UsernameNotFoundException.class)
+    public ResponseEntity<ApiResponse<Object>> usernameNotFoundExceptionHandler(Exception e) {
+        final ApiResponse<Object> response = ApiResponse.failure(ResultCode.FORBIDDEN,
+                e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.FORBIDDEN);
+    }
+
+    @ExceptionHandler(value = AuthorizationFailureException.class)
+    public ResponseEntity<ApiResponse<Object>> authorizationFailureExceptionHandler(Exception e) {
+        final ApiResponse<Object> response = ApiResponse.failure(ResultCode.UNAUTHORIZED,
+            e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
+    }
+
 }

--- a/src/main/java/com/dahhong/whoami/global/exception/customException/AuthorizationFailureException.java
+++ b/src/main/java/com/dahhong/whoami/global/exception/customException/AuthorizationFailureException.java
@@ -1,0 +1,11 @@
+package com.dahhong.whoami.global.exception.customException;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class AuthorizationFailureException extends AuthenticationException {
+
+    public AuthorizationFailureException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/global/response/ApiResponse.java
+++ b/src/main/java/com/dahhong/whoami/global/response/ApiResponse.java
@@ -1,7 +1,7 @@
 package com.dahhong.whoami.global.response;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.dahhong.whoami.global.response.enums.ResultCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 import lombok.ToString;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/dahhong/whoami/global/response/enums/ResultCode.java
+++ b/src/main/java/com/dahhong/whoami/global/response/enums/ResultCode.java
@@ -10,7 +10,8 @@ public enum ResultCode {
     BAD_REQUEST("요청에 오류가 있습니다.", "400"),
     FORBIDDEN("허용되지 않은 접근입니다.", "403"),
     NOT_FOUND("대상이 존재하지 않습니다.", "404"),
-    INTERNAL_SERVER_ERROR("서버에 오류가 발생했습니다. 잠시 후 다시 시도해주세요.", "500");
+    INTERNAL_SERVER_ERROR("서버에 오류가 발생했습니다. 잠시 후 다시 시도해주세요.", "500"),
+    UNAUTHORIZED("인증에 실패했습니다.", "401");
 
     private final String message;
 

--- a/src/main/java/com/dahhong/whoami/global/security/SecurityConfig.java
+++ b/src/main/java/com/dahhong/whoami/global/security/SecurityConfig.java
@@ -1,19 +1,52 @@
 package com.dahhong.whoami.global.security;
 
+import com.dahhong.whoami.global.security.authenticationProvider.KakaoAuthenticationProvider;
+import com.dahhong.whoami.global.security.filter.KakaoJwtAuthenticationFilter;
+import com.dahhong.whoami.user.application.port.out.UserQueryPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.client.RestTemplate;
 
-@RequiredArgsConstructor
-@EnableWebSecurity
 @Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final UserQueryPort userQueryPort;
+
+    private final KakaoAuthenticationProvider kakaoAuthenticationProvider;
+
+    private final RestTemplate restTemplate;
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> web.ignoring()
+                .requestMatchers("/error", "/favicon.ico");
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorizeRequests -> authorizeRequests
+                        .requestMatchers("/api/v1/auth/kakao/login").permitAll()
+                        .requestMatchers("/api/v1/auth/kakao/callback").permitAll()
+                        .requestMatchers("/api/v1/auth/kakao/refresh").permitAll()
+                        .requestMatchers("/api/v1/auth/kakao/**").authenticated()
+                        .anyRequest().permitAll()
+                )
+                .addFilterBefore(new KakaoJwtAuthenticationFilter(userQueryPort, kakaoAuthenticationProvider, restTemplate), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 

--- a/src/main/java/com/dahhong/whoami/global/security/SecurityConfig.java
+++ b/src/main/java/com/dahhong/whoami/global/security/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.dahhong.whoami.user.application.port.out.UserQueryPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -35,11 +36,14 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorizeRequests -> authorizeRequests
+                        .requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/", "/error", "/favicon.ico", "/**/*.png", "/**/*.gif", "/**/*.svg", "/**/*.jpg", "/**/*.html", "/**/*.css", "/**/*.js").permitAll()
                         .requestMatchers("/api/v1/auth/kakao/login").permitAll()
                         .requestMatchers("/api/v1/auth/kakao/callback").permitAll()
                         .requestMatchers("/api/v1/auth/kakao/refresh").permitAll()

--- a/src/main/java/com/dahhong/whoami/global/security/authenticationProvider/KakaoAuthenticationProvider.java
+++ b/src/main/java/com/dahhong/whoami/global/security/authenticationProvider/KakaoAuthenticationProvider.java
@@ -1,0 +1,31 @@
+package com.dahhong.whoami.global.security.authenticationProvider;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoAuthenticationProvider implements AuthenticationProvider {
+
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        UserDetails userDetails = userDetailsService.loadUserByUsername((String) authentication.getPrincipal());
+        return new UsernamePasswordAuthenticationToken(userDetails.getUsername(), userDetails.getPassword());
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return false;
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/global/security/filter/KakaoJwtAuthenticationFilter.java
+++ b/src/main/java/com/dahhong/whoami/global/security/filter/KakaoJwtAuthenticationFilter.java
@@ -1,0 +1,100 @@
+package com.dahhong.whoami.global.security.filter;
+
+import com.dahhong.whoami.global.exception.customException.AuthorizationFailureException;
+import com.dahhong.whoami.global.security.authenticationProvider.KakaoAuthenticationProvider;
+import com.dahhong.whoami.global.security.filter.dto.AccessTokenVerificationResponseDto;
+import com.dahhong.whoami.user.application.port.out.UserQueryPort;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import net.minidev.json.JSONObject;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.filter.GenericFilterBean;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+
+@RequiredArgsConstructor
+public class KakaoJwtAuthenticationFilter extends GenericFilterBean {
+
+    private final UserQueryPort userQueryPort;
+
+    private final KakaoAuthenticationProvider kakaoAuthenticationProvider;
+
+    private final RestTemplate restTemplate;
+
+    private final String ROOT_URI = "https://kapi.kakao.com";
+
+    private final String ACCESS_TOKEN_VERIFICATION_URL = "/v1/user/access_token_info";
+
+    private boolean verification(String id) {
+        return userQueryPort.findById(id).isPresent();
+    }
+
+    private String extractUserId(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+
+        URI uri = UriComponentsBuilder
+                .fromUriString(ROOT_URI)
+                .path(ACCESS_TOKEN_VERIFICATION_URL)
+                .build()
+                .toUri();
+
+        try {
+            ResponseEntity<AccessTokenVerificationResponseDto> response = restTemplate.exchange(uri, HttpMethod.GET, request, AccessTokenVerificationResponseDto.class);
+            return response.getBody().getId().toString();
+        } catch (RestClientException | NullPointerException e) {
+            throw new AuthorizationFailureException("카카오 서버에서 유저 토큰을 인증하는 것에 실패했습니다.", e.getCause());
+        }
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        Authentication authenticate;
+
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+        String accessToken = request.getHeader("Authorization") != null ? request.getHeader("Authorization").substring(7) : null;
+
+        // 엑세스 토큰이 NULL일 경우 다음 필터에서 인증의 책임을 가진다
+        if (accessToken == null) {
+            filterChain.doFilter(servletRequest, servletResponse);
+            return;
+        }
+
+        String userId = extractUserId(accessToken);
+        if (verification(userId)) {
+            try {
+                authenticate = kakaoAuthenticationProvider.authenticate(new UsernamePasswordAuthenticationToken(userId, ""));
+                SecurityContextHolder.getContext().setAuthentication(authenticate);
+            } catch(Exception e) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json");
+                response.setCharacterEncoding("UTF-8");
+
+                JSONObject resJson = new JSONObject();
+                resJson.put("code", 401);
+                resJson.put("message", e.getMessage());
+
+                response.getWriter().write(resJson.toString());
+            }
+        }
+
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/global/security/filter/dto/AccessTokenVerificationResponseDto.java
+++ b/src/main/java/com/dahhong/whoami/global/security/filter/dto/AccessTokenVerificationResponseDto.java
@@ -1,0 +1,20 @@
+package com.dahhong.whoami.global.security.filter.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AccessTokenVerificationResponseDto {
+
+    private Long id;
+
+    private Integer expires_in;
+
+    private Integer app_id;
+
+}

--- a/src/main/java/com/dahhong/whoami/user/adapter/out/UserCommandAdapter.java
+++ b/src/main/java/com/dahhong/whoami/user/adapter/out/UserCommandAdapter.java
@@ -1,0 +1,25 @@
+package com.dahhong.whoami.user.adapter.out;
+
+import com.dahhong.whoami.user.application.port.out.UserCommandPort;
+import com.dahhong.whoami.user.domain.entity.User;
+import com.dahhong.whoami.user.infrastructure.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserCommandAdapter implements UserCommandPort {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public User save(User user) {
+        return userRepository.save(user);
+    }
+
+    @Override
+    public void delete(User user) {
+        userRepository.delete(user);
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/user/adapter/out/UserQueryAdapter.java
+++ b/src/main/java/com/dahhong/whoami/user/adapter/out/UserQueryAdapter.java
@@ -1,0 +1,21 @@
+package com.dahhong.whoami.user.adapter.out;
+
+import com.dahhong.whoami.user.application.port.out.UserQueryPort;
+import com.dahhong.whoami.user.domain.entity.User;
+import com.dahhong.whoami.user.infrastructure.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class UserQueryAdapter implements UserQueryPort {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public Optional<User> findById(String userId) {
+        return userRepository.findById(userId);
+    }
+}

--- a/src/main/java/com/dahhong/whoami/user/application/port/in/GetUserUseCase.java
+++ b/src/main/java/com/dahhong/whoami/user/application/port/in/GetUserUseCase.java
@@ -1,0 +1,11 @@
+package com.dahhong.whoami.user.application.port.in;
+
+import com.dahhong.whoami.user.domain.entity.User;
+
+public interface GetUserUseCase {
+
+    User getUser(String userId);
+
+    boolean isExistUser(String userId);
+
+}

--- a/src/main/java/com/dahhong/whoami/user/application/port/in/JoinKakaoUserUseCase.java
+++ b/src/main/java/com/dahhong/whoami/user/application/port/in/JoinKakaoUserUseCase.java
@@ -1,0 +1,7 @@
+package com.dahhong.whoami.user.application.port.in;
+
+public interface JoinKakaoUserUseCase {
+
+    void joinKakaoUser(String id, String nickname, String profileImage);
+
+}

--- a/src/main/java/com/dahhong/whoami/user/application/port/in/QuitUserUseCase.java
+++ b/src/main/java/com/dahhong/whoami/user/application/port/in/QuitUserUseCase.java
@@ -1,0 +1,7 @@
+package com.dahhong.whoami.user.application.port.in;
+
+public interface QuitUserUseCase {
+
+    void quitUser(String userId);
+
+}

--- a/src/main/java/com/dahhong/whoami/user/application/port/out/UserCommandPort.java
+++ b/src/main/java/com/dahhong/whoami/user/application/port/out/UserCommandPort.java
@@ -1,0 +1,11 @@
+package com.dahhong.whoami.user.application.port.out;
+
+import com.dahhong.whoami.user.domain.entity.User;
+
+public interface UserCommandPort {
+
+    User save(User user);
+
+    void delete(User user);
+
+}

--- a/src/main/java/com/dahhong/whoami/user/application/port/out/UserQueryPort.java
+++ b/src/main/java/com/dahhong/whoami/user/application/port/out/UserQueryPort.java
@@ -1,0 +1,11 @@
+package com.dahhong.whoami.user.application.port.out;
+
+import com.dahhong.whoami.user.domain.entity.User;
+
+import java.util.Optional;
+
+public interface UserQueryPort {
+
+    Optional<User> findById(String userId);
+
+}

--- a/src/main/java/com/dahhong/whoami/user/application/service/GetUserService.java
+++ b/src/main/java/com/dahhong/whoami/user/application/service/GetUserService.java
@@ -1,0 +1,26 @@
+package com.dahhong.whoami.user.application.service;
+
+import com.dahhong.whoami.global.exception.customException.NotFoundException;
+import com.dahhong.whoami.user.application.port.in.GetUserUseCase;
+import com.dahhong.whoami.user.application.port.out.UserQueryPort;
+import com.dahhong.whoami.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetUserService implements GetUserUseCase {
+
+    private final UserQueryPort userQueryPort;
+
+    @Override
+    public User getUser(String userId) {
+        return userQueryPort.findById(userId).orElseThrow(() -> new NotFoundException("유저를 찾을 수 없습니다."));
+    }
+
+    @Override
+    public boolean isExistUser(String userId) {
+        return userQueryPort.findById(userId).isPresent();
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/user/application/service/JoinKakaoUserService.java
+++ b/src/main/java/com/dahhong/whoami/user/application/service/JoinKakaoUserService.java
@@ -1,0 +1,30 @@
+package com.dahhong.whoami.user.application.service;
+
+import com.dahhong.whoami.user.application.port.in.GetUserUseCase;
+import com.dahhong.whoami.user.application.port.in.JoinKakaoUserUseCase;
+import com.dahhong.whoami.user.application.port.out.UserCommandPort;
+import com.dahhong.whoami.user.domain.entity.AuthType;
+import com.dahhong.whoami.user.domain.entity.User;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JoinKakaoUserService implements JoinKakaoUserUseCase {
+
+    private final UserCommandPort userCommandPort;
+
+    private final GetUserUseCase getUserUseCase;
+
+    @Override
+    @Transactional
+    public void joinKakaoUser(String id, String nickname, String profileImage) {
+        if (getUserUseCase.isExistUser(id)) {
+            return;
+        }
+        User user = User.of(id, AuthType.KAKAO, nickname, profileImage);
+        userCommandPort.save(user);
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/user/application/service/JoinKakaoUserService.java
+++ b/src/main/java/com/dahhong/whoami/user/application/service/JoinKakaoUserService.java
@@ -4,6 +4,7 @@ import com.dahhong.whoami.user.application.port.in.GetUserUseCase;
 import com.dahhong.whoami.user.application.port.in.JoinKakaoUserUseCase;
 import com.dahhong.whoami.user.application.port.out.UserCommandPort;
 import com.dahhong.whoami.user.domain.entity.AuthType;
+import com.dahhong.whoami.user.domain.entity.Role;
 import com.dahhong.whoami.user.domain.entity.User;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +24,7 @@ public class JoinKakaoUserService implements JoinKakaoUserUseCase {
         if (getUserUseCase.isExistUser(id)) {
             return;
         }
-        User user = User.of(id, AuthType.KAKAO, nickname, profileImage);
+        User user = User.of(id, Role.USER, AuthType.KAKAO, nickname, profileImage);
         userCommandPort.save(user);
     }
 

--- a/src/main/java/com/dahhong/whoami/user/application/service/QuitUserService.java
+++ b/src/main/java/com/dahhong/whoami/user/application/service/QuitUserService.java
@@ -1,0 +1,26 @@
+package com.dahhong.whoami.user.application.service;
+
+import com.dahhong.whoami.user.application.port.in.GetUserUseCase;
+import com.dahhong.whoami.user.application.port.in.QuitUserUseCase;
+import com.dahhong.whoami.user.application.port.out.UserCommandPort;
+import com.dahhong.whoami.user.domain.entity.User;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QuitUserService implements QuitUserUseCase {
+
+    private final GetUserUseCase getUserUseCase;
+
+    private final UserCommandPort userCommandPort;
+
+    @Override
+    @Transactional
+    public void quitUser(String userId) {
+        User user = getUserUseCase.getUser(userId);
+        userCommandPort.delete(user);
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/user/domain/entity/AuthType.java
+++ b/src/main/java/com/dahhong/whoami/user/domain/entity/AuthType.java
@@ -1,0 +1,5 @@
+package com.dahhong.whoami.user.domain.entity;
+
+public enum AuthType {
+    NORMAL, KAKAO
+}

--- a/src/main/java/com/dahhong/whoami/user/domain/entity/Role.java
+++ b/src/main/java/com/dahhong/whoami/user/domain/entity/Role.java
@@ -1,0 +1,13 @@
+package com.dahhong.whoami.user.domain.entity;
+
+import org.springframework.security.core.GrantedAuthority;
+
+public enum Role implements GrantedAuthority {
+    USER, ADMIN;
+
+    @Override
+    public String getAuthority() {
+        return name();
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/user/domain/entity/User.java
+++ b/src/main/java/com/dahhong/whoami/user/domain/entity/User.java
@@ -16,6 +16,9 @@ public class User {
     private String id;
 
     @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Enumerated(EnumType.STRING)
     private AuthType authType;
 
     @Column(length = 100)
@@ -24,8 +27,8 @@ public class User {
     @Column(length = 1000)
     private String profilePicture;
 
-    public static User of(String id, AuthType authType, String name, String profilePicture) {
-        return new User(id, authType, name, profilePicture);
+    public static User of(String id, Role role, AuthType authType, String name, String profilePicture) {
+        return new User(id, role, authType, name, profilePicture);
     }
 
 }

--- a/src/main/java/com/dahhong/whoami/user/domain/entity/User.java
+++ b/src/main/java/com/dahhong/whoami/user/domain/entity/User.java
@@ -1,0 +1,31 @@
+package com.dahhong.whoami.user.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "WAI_USER")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class User {
+    @Id
+    private String id;
+
+    @Enumerated(EnumType.STRING)
+    private AuthType authType;
+
+    @Column(length = 100)
+    private String name;
+
+    @Column(length = 1000)
+    private String profilePicture;
+
+    public static User of(String id, AuthType authType, String name, String profilePicture) {
+        return new User(id, authType, name, profilePicture);
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/user/infrastructure/repository/UserRepository.java
+++ b/src/main/java/com/dahhong/whoami/user/infrastructure/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.dahhong.whoami.user.infrastructure.repository;
+
+import com.dahhong.whoami.user.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, String> {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,3 +25,7 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.servlet.multipart.enabled=true
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
+
+# Kakao Key
+kakao.client.id=${kakaoClientId}
+kakao.redirect.uri=${kakaoRedirectUri}


### PR DESCRIPTION
### 요약
Kakao를 이용한 서비스 인증/인가 로직&문서화 완료

### 상세
- [Kakao 소셜 통합 로그인/회원가입 구현](https://github.com/fing9/whoami/pull/1)
- [Kakao 소셜 로그아웃/회원탈퇴 기능 구현](https://github.com/fing9/whoami/pull/2)
- [Spring Security를 이용한 카카오 소셜 회원 관리 기능 추가](https://github.com/fing9/whoami/pull/3)
- [Swagger를 이용한 Kakao OAuth 관련 API 문서화](https://github.com/fing9/whoami/pull/4)
