### PR TITLE
feat: 유저 정보 조회 api 추가

### DIFF
--- a/src/main/java/com/dahhong/whoami/global/security/SecurityConfig.java
+++ b/src/main/java/com/dahhong/whoami/global/security/SecurityConfig.java
@@ -3,9 +3,11 @@ package com.dahhong.whoami.global.security;
 import com.dahhong.whoami.global.security.authenticationProvider.KakaoAuthenticationProvider;
 import com.dahhong.whoami.global.security.filter.KakaoJwtAuthenticationFilter;
 import com.dahhong.whoami.user.application.port.out.UserQueryPort;
+import com.dahhong.whoami.user.domain.entity.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -48,6 +50,14 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/auth/kakao/callback").permitAll()
                         .requestMatchers("/api/v1/auth/kakao/refresh").permitAll()
                         .requestMatchers("/api/v1/auth/kakao/**").authenticated()
+                        /* page 엔드포인트에 대한 권한 처리 */
+                        .requestMatchers("/api/v1/page/create").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/page/{id}").authenticated()
+                        .requestMatchers(HttpMethod.PUT, "/api/v1/page/{id}").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/page/{id}").authenticated()
+                        /* User 엔드포인트에 대한 권한 처리 */
+                        .requestMatchers("/api/v1/user/**").authenticated()
+                        .requestMatchers("/api/v1/user/info/all").hasRole(String.valueOf(Role.ADMIN))
                         .anyRequest().permitAll()
                 )
                 .addFilterBefore(new KakaoJwtAuthenticationFilter(userQueryPort, kakaoAuthenticationProvider, restTemplate), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/dahhong/whoami/user/adapter/in/UserController.java
+++ b/src/main/java/com/dahhong/whoami/user/adapter/in/UserController.java
@@ -3,6 +3,7 @@ package com.dahhong.whoami.user.adapter.in;
 import com.dahhong.whoami.global.exception.customException.AuthorizationFailureException;
 import com.dahhong.whoami.global.response.ApiResponse;
 import com.dahhong.whoami.user.adapter.in.dto.UserInfoDto;
+import com.dahhong.whoami.user.adapter.in.swagger.UserControllerSwagger;
 import com.dahhong.whoami.user.application.port.in.GetUserUseCase;
 import com.dahhong.whoami.user.domain.entity.Role;
 import com.dahhong.whoami.user.domain.entity.User;
@@ -16,7 +17,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/user")
-public class UserController {
+public class UserController implements UserControllerSwagger {
 	private final GetUserUseCase getUserUseCase;
 
 	@GetMapping("/info")

--- a/src/main/java/com/dahhong/whoami/user/adapter/in/UserController.java
+++ b/src/main/java/com/dahhong/whoami/user/adapter/in/UserController.java
@@ -22,15 +22,13 @@ public class UserController implements UserControllerSwagger {
 
 	@GetMapping("/info")
 	public ResponseEntity<?> getUser(@AuthenticationPrincipal String userId) {
+		//SecurityConfig에서 권한이 필터됨
 		User user = getUserUseCase.getUser(userId);
 		return ResponseEntity.ok(ApiResponse.success(UserInfoDto.of(user)));
 	}
 
 	@GetMapping("/info/all")
-	public ResponseEntity<?> getAllUsers(@AuthenticationPrincipal String userId) {
-		if (getUserUseCase.getUser(userId).getRole() != Role.ADMIN) {
-			throw new AuthorizationFailureException("다른 유저 정보에 접근할 수 있는 권한이 없습니다.", null);
-		}
+	public ResponseEntity<?> getAllUsers() {
 		List<UserInfoDto> users = getUserUseCase.getAllUsers().stream().map((user) -> UserInfoDto.of(user)).toList();
 		return ResponseEntity.ok(ApiResponse.success(users));
 	}

--- a/src/main/java/com/dahhong/whoami/user/adapter/in/UserController.java
+++ b/src/main/java/com/dahhong/whoami/user/adapter/in/UserController.java
@@ -1,0 +1,45 @@
+package com.dahhong.whoami.user.adapter.in;
+
+import com.dahhong.whoami.global.exception.customException.AuthorizationFailureException;
+import com.dahhong.whoami.global.response.ApiResponse;
+import com.dahhong.whoami.user.adapter.in.dto.UserInfoDto;
+import com.dahhong.whoami.user.application.port.in.GetUserUseCase;
+import com.dahhong.whoami.user.domain.entity.Role;
+import com.dahhong.whoami.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/user")
+public class UserController {
+	private final GetUserUseCase getUserUseCase;
+
+	@GetMapping("/info")
+	public ResponseEntity<?> getUser(@AuthenticationPrincipal String userId) {
+		User user = getUserUseCase.getUser(userId);
+		return ResponseEntity.ok(ApiResponse.success(UserInfoDto.of(user)));
+	}
+
+	@GetMapping("/info/all")
+	public ResponseEntity<?> getAllUsers(@AuthenticationPrincipal String userId) {
+		if (getUserUseCase.getUser(userId).getRole() != Role.ADMIN) {
+			throw new AuthorizationFailureException("다른 유저 정보에 접근할 수 있는 권한이 없습니다.", null);
+		}
+		List<UserInfoDto> users = getUserUseCase.getAllUsers().stream().map((user) -> UserInfoDto.of(user)).toList();
+		return ResponseEntity.ok(ApiResponse.success(users));
+	}
+
+	@GetMapping("/info/{id}")
+	public ResponseEntity<?> getUser(@PathVariable String id, @AuthenticationPrincipal String userId) {
+		if (!id.equals(userId) && getUserUseCase.getUser(userId).getRole() != Role.ADMIN) {
+			throw new AuthorizationFailureException("다른 유저 정보에 접근할 수 있는 권한이 없습니다.", null);
+		}
+		User user = getUserUseCase.getUser(id);
+		return ResponseEntity.ok(ApiResponse.success(UserInfoDto.of(user)));
+	}
+}

--- a/src/main/java/com/dahhong/whoami/user/adapter/in/dto/UserInfoDto.java
+++ b/src/main/java/com/dahhong/whoami/user/adapter/in/dto/UserInfoDto.java
@@ -1,0 +1,27 @@
+package com.dahhong.whoami.user.adapter.in.dto;
+
+import com.dahhong.whoami.user.domain.entity.AuthType;
+import com.dahhong.whoami.user.domain.entity.Role;
+import com.dahhong.whoami.user.domain.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserInfoDto {
+	private String id;
+	private Role role;
+	private AuthType authType;
+	private String name;
+	private String profilePicture;
+
+	public static UserInfoDto of(User user) {
+		return new UserInfoDto(
+				user.getId(),
+				user.getRole(),
+				user.getAuthType(),
+				user.getName(),
+				user.getProfilePicture()
+		);
+	}
+}

--- a/src/main/java/com/dahhong/whoami/user/adapter/in/swagger/UserControllerSwagger.java
+++ b/src/main/java/com/dahhong/whoami/user/adapter/in/swagger/UserControllerSwagger.java
@@ -1,0 +1,29 @@
+package com.dahhong.whoami.user.adapter.in.swagger;
+
+import com.dahhong.whoami.global.response.ApiResponse;
+import com.dahhong.whoami.user.adapter.in.dto.UserInfoDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+@Tag(name = "유저", description = "유저 관련 API")
+public interface UserControllerSwagger {
+
+	@Operation(summary = "유저 정보 조회", description = "현재 인증된 유저의 정보를 조회합니다. 별도의 인자 없이 요청만 하면 됨. 백엔드에서 현재 로그인 정보를 확인함")
+	ResponseEntity<?> getUser(@AuthenticationPrincipal String userId);
+
+	@Operation(summary = "모든 유저 정보 조회(ADMIN)", description = "모든 유저의 정보를 조회합니다. 이 API는 관리자만 접근할 수 있습니다.")
+	ResponseEntity<?> getAllUsers(@AuthenticationPrincipal String userId);
+
+	@Operation(summary = "특정 유저 정보 조회(본인 정보가 아닌 경우 ADMIN이어야 함)", description = "특정 유저의 정보를 조회합니다. 관리자는 다른 유저의 정보를 조회할 수 있습니다.")
+	@Parameters({
+			@Parameter(name = "id", description = "조회할 유저의 ID", required = true)
+	})
+	ResponseEntity<?> getUser(@PathVariable String id, @AuthenticationPrincipal String userId);
+}

--- a/src/main/java/com/dahhong/whoami/user/adapter/in/swagger/UserControllerSwagger.java
+++ b/src/main/java/com/dahhong/whoami/user/adapter/in/swagger/UserControllerSwagger.java
@@ -19,7 +19,7 @@ public interface UserControllerSwagger {
 	ResponseEntity<?> getUser(@AuthenticationPrincipal String userId);
 
 	@Operation(summary = "모든 유저 정보 조회(ADMIN)", description = "모든 유저의 정보를 조회합니다. 이 API는 관리자만 접근할 수 있습니다.")
-	ResponseEntity<?> getAllUsers(@AuthenticationPrincipal String userId);
+	ResponseEntity<?> getAllUsers();
 
 	@Operation(summary = "특정 유저 정보 조회(본인 정보가 아닌 경우 ADMIN이어야 함)", description = "특정 유저의 정보를 조회합니다. 관리자는 다른 유저의 정보를 조회할 수 있습니다.")
 	@Parameters({

--- a/src/main/java/com/dahhong/whoami/user/adapter/out/UserQueryAdapter.java
+++ b/src/main/java/com/dahhong/whoami/user/adapter/out/UserQueryAdapter.java
@@ -6,6 +6,7 @@ import com.dahhong.whoami.user.infrastructure.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -18,4 +19,7 @@ public class UserQueryAdapter implements UserQueryPort {
     public Optional<User> findById(String userId) {
         return userRepository.findById(userId);
     }
+
+    @Override
+    public List<User> findAll() { return userRepository.findAll(); }
 }

--- a/src/main/java/com/dahhong/whoami/user/application/port/in/GetUserUseCase.java
+++ b/src/main/java/com/dahhong/whoami/user/application/port/in/GetUserUseCase.java
@@ -2,10 +2,13 @@ package com.dahhong.whoami.user.application.port.in;
 
 import com.dahhong.whoami.user.domain.entity.User;
 
+import java.util.List;
+
 public interface GetUserUseCase {
 
     User getUser(String userId);
 
     boolean isExistUser(String userId);
 
+    List<User> getAllUsers();
 }

--- a/src/main/java/com/dahhong/whoami/user/application/port/out/UserQueryPort.java
+++ b/src/main/java/com/dahhong/whoami/user/application/port/out/UserQueryPort.java
@@ -2,10 +2,12 @@ package com.dahhong.whoami.user.application.port.out;
 
 import com.dahhong.whoami.user.domain.entity.User;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserQueryPort {
 
     Optional<User> findById(String userId);
 
+    List<User> findAll();
 }

--- a/src/main/java/com/dahhong/whoami/user/application/service/GetUserService.java
+++ b/src/main/java/com/dahhong/whoami/user/application/service/GetUserService.java
@@ -7,6 +7,8 @@ import com.dahhong.whoami.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class GetUserService implements GetUserUseCase {
@@ -21,6 +23,11 @@ public class GetUserService implements GetUserUseCase {
     @Override
     public boolean isExistUser(String userId) {
         return userQueryPort.findById(userId).isPresent();
+    }
+
+    @Override
+    public List<User> getAllUsers() {
+        return userQueryPort.findAll();
     }
 
 }


### PR DESCRIPTION
1. 현재 로그인된 유저 정보 조회 : 별도의 인자 없이 요청만 보내고, 백엔드에서 로그인 정보 확인
2. 모든 유저 정보 조회 : `Role.ADMIN`인 유저만 가능
3. 특정 유저 정보 조회 : `userId`에 해당하는 유저 정보 조회하는데, 다른 유저에 대한 조회는 `Role.ADMIN`인 유저만 가능