### PR TITLE
[feat] auth api v2  추가 => /callback, /refresh

### DIFF
--- a/src/main/java/com/dahhong/whoami/auth/adapter/in/KakaoOauthControllerV2.java
+++ b/src/main/java/com/dahhong/whoami/auth/adapter/in/KakaoOauthControllerV2.java
@@ -1,0 +1,62 @@
+package com.dahhong.whoami.auth.adapter.in;
+
+import com.dahhong.whoami.auth.adapter.in.dto.KakaoCallbackResponseDto;
+import com.dahhong.whoami.auth.adapter.in.swagger.KakaoOauthControllerSwaggerV2;
+import com.dahhong.whoami.auth.application.port.in.KakaoTokenRefreshUseCase;
+import com.dahhong.whoami.auth.application.port.in.LoginKakaoUseCase;
+import com.dahhong.whoami.auth.application.port.in.LogoutKakaoUseCase;
+import com.dahhong.whoami.auth.application.port.in.QuitKakaoUseCase;
+import com.dahhong.whoami.auth.application.service.dto.TokenRefreshResponseDto;
+import com.dahhong.whoami.global.response.ApiResponse;
+import com.dahhong.whoami.user.application.port.in.QuitUserUseCase;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.query.Param;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/auth/kakao")
+public class KakaoOauthControllerV2 implements KakaoOauthControllerSwaggerV2 {
+
+	private final LoginKakaoUseCase loginKakaoUseCase;
+
+	private final KakaoTokenRefreshUseCase kakaoTokenRefreshUseCase;
+
+	@GetMapping("/callback")
+	public ResponseEntity<ApiResponse<KakaoCallbackResponseDto>> callbackByKakao(@Param("code") String code, HttpServletResponse response) {
+		KakaoCallbackResponseDto responseDto = loginKakaoUseCase.loginKakao(code);
+
+		// Refresh Token은 cookie에 직접 넣어주기.
+		Cookie cookie = new Cookie("Refresh_Token", responseDto.getRefreshToken());
+		responseDto.setRefreshToken(""); //쿠키에 넣어줄거임
+		cookie.setMaxAge(7 * 24 * 60 * 60); //만료 일주일
+		cookie.setPath("/");
+		cookie.setSecure(true);
+		cookie.setHttpOnly(true);
+		response.addCookie(cookie);
+
+		return ResponseEntity.ok(ApiResponse.success(responseDto));
+	}
+
+	@PostMapping("/refresh")
+	public ResponseEntity<ApiResponse<TokenRefreshResponseDto>> refresh(@CookieValue("Refresh_Token") String refreshToken, HttpServletResponse response) {
+		TokenRefreshResponseDto newTokenPair = kakaoTokenRefreshUseCase.refresh(refreshToken);
+
+		if(newTokenPair.getRefresh_token() != null) { //refresh token도 재발급된 경우
+			// Refresh Token은 cookie에 직접 넣어주기.
+			Cookie cookie = new Cookie("Refresh_Token", newTokenPair.getRefresh_token());
+			newTokenPair.setRefresh_token(""); //쿠키에 넣어줄거임
+			cookie.setMaxAge(7 * 24 * 60 * 60); //만료 일주일
+			cookie.setPath("/");
+			cookie.setSecure(true);
+			cookie.setHttpOnly(true);
+			response.addCookie(cookie);
+
+		}
+
+		return ResponseEntity.ok(ApiResponse.success(newTokenPair));
+	}
+}

--- a/src/main/java/com/dahhong/whoami/auth/adapter/in/swagger/KakaoOauthControllerSwaggerV2.java
+++ b/src/main/java/com/dahhong/whoami/auth/adapter/in/swagger/KakaoOauthControllerSwaggerV2.java
@@ -1,0 +1,27 @@
+package com.dahhong.whoami.auth.adapter.in.swagger;
+
+import com.dahhong.whoami.auth.adapter.in.dto.KakaoCallbackResponseDto;
+import com.dahhong.whoami.auth.application.service.dto.TokenRefreshResponseDto;
+import com.dahhong.whoami.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+
+public interface KakaoOauthControllerSwaggerV2 {
+
+	@Tag(name = "카카오 로그인/회원가입", description = "카카오 로그인 콜백")
+	@Operation(summary = "카카오 로그인 콜백  V2!!", description = "카카오 OAuth2 정보 동의를 마무리 한 뒤, 리다이렉트 되는 콜백 URL 입니다. \n v2 : Refresh_Token은 직접 http-only cookie로 넣어주고 빈 값을 반환합니다.")
+	@Parameters({
+			@Parameter(name = "code", description = "카카오 정보 동의시에 자동으로 발급되는 Code 값 (일반적으로 직접 넣어줄 필요가 없습니다.)", required = true)
+	})
+	ResponseEntity<ApiResponse<KakaoCallbackResponseDto>> callbackByKakao(String code, HttpServletResponse response);
+
+
+	@Tag(name = "카카오 JWT 토큰 갱신", description = "카카오 토큰 갱신")
+	@Operation(summary = "카카오 토큰 갱신 V2!!", description = "카카오 OAuth2를 통해 로그인한 사용자의 토큰을 Refresh Token을 사용해 갱신합니다.  \n v2: Cookie에서 꺼냅니다.")
+	ResponseEntity<ApiResponse<TokenRefreshResponseDto>> refresh(@Parameter(hidden = true) @CookieValue("Refresh_Token") String refreshToken, HttpServletResponse response);
+}

--- a/src/main/java/com/dahhong/whoami/auth/application/service/KakaoTokenRefreshService.java
+++ b/src/main/java/com/dahhong/whoami/auth/application/service/KakaoTokenRefreshService.java
@@ -23,7 +23,7 @@ public class KakaoTokenRefreshService implements KakaoTokenRefreshUseCase {
 
     private final RestTemplate restTemplate;
 
-    private final String ROOT_URI = "https://kapi.kakao.com";
+    private final String ROOT_URI = "https://kauth.kakao.com";
 
     private final String ACCESS_TOKEN_REFRESH_URL = "/oauth/token";
 


### PR DESCRIPTION
- `/callback` : `Refresh_Token`은 쿠키(path : `/`, security true, http-only true)에 바로 넣어주고, 반환은 refresh token 비워서 보냄
- `/refresh` : request header의 cookie에서 `Refresh_Token`을 꺼내서 refresh하도록 함