### PR TITLE
[feat] 기능 추가 : reply

### DIFF
--- a/src/main/java/com/dahhong/whoami/page/adapter/in/PageController.java
+++ b/src/main/java/com/dahhong/whoami/page/adapter/in/PageController.java
@@ -90,16 +90,14 @@ public class PageController implements PageControllerSwagger {
 		return ResponseEntity.ok(ApiResponse.success(pagesOfUser));
 	}
 
-	@Override
 	@PostMapping("/replies/{pageId}")
-	public ResponseEntity<?> createReplyToPage(@Positive @PathVariable Long pageId, @Valid @RequestBody ReplyRequestDto replyRequest) {
+	public ResponseEntity<?> createReplyToPage(@PathVariable Long pageId, @Valid @RequestBody ReplyRequestDto replyRequest) {
 		Reply createdReply = createReplyUseCase.createReply(pageId, replyRequest.getReplyUsername(), replyRequest.getContent());
 		return ResponseEntity.ok(ApiResponse.success(new CreateReplyResponseDto("성공적으로 답변을 생성하였습니다.", createdReply.getId())));
 	}
 
-	@Override
 	@GetMapping("/replies/{pageId}")
-	public ResponseEntity<?> getRepliesOfPage(@Positive @PathVariable Long pageId) {
+	public ResponseEntity<?> getRepliesOfPage(@PathVariable Long pageId) {
 		List<GetReplyResponseDto> replies = getReplyUseCase.getRepliesOfPage(pageId).stream().map((reply)-> GetReplyResponseDto.of(reply, pageId)).toList();
 		return ResponseEntity.ok(ApiResponse.success(replies));
 	}

--- a/src/main/java/com/dahhong/whoami/page/adapter/in/swagger/PageControllerSwagger.java
+++ b/src/main/java/com/dahhong/whoami/page/adapter/in/swagger/PageControllerSwagger.java
@@ -7,14 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Positive;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "페이지", description = "페이지 관련 CRUD API")
 public interface PageControllerSwagger {
@@ -30,19 +23,19 @@ public interface PageControllerSwagger {
 
 	@Operation(summary = "페이지 생성", description = "새로운 페이지를 생성합니다.")
 	@Parameters()
-	ResponseEntity<?> createPage(PageRequestDto pageRequest, @AuthenticationPrincipal String userId);
+	ResponseEntity<?> createPage(PageRequestDto pageRequest, String userId);
 
 	@Operation(summary = "페이지 수정", description = "특정 ID에 해당하는 페이지를 수정합니다.")
 	@Parameters({
 			@Parameter(name = "id", description = "수정할 페이지의 ID", required = true),
 	})
-	ResponseEntity<?> updatePage(Long id, PageRequestDto pageRequest, @AuthenticationPrincipal String userId);
+	ResponseEntity<?> updatePage(Long id, PageRequestDto pageRequest, String userId);
 
 	@Operation(summary = "페이지 삭제", description = "특정 ID에 해당하는 페이지를 삭제합니다.")
 	@Parameters({
 			@Parameter(name = "id", description = "삭제할 페이지의 ID", required = true)
 	})
-	ResponseEntity<?> deletePage(Long id , @AuthenticationPrincipal String userId);
+	ResponseEntity<?> deletePage(Long id , String userId);
 
 	@Operation(summary = "특정 사용자의 모든 페이지 조회", description = "특정 사용자의 모든 페이지를 조회합니다.")
 	@Parameters({

--- a/src/main/java/com/dahhong/whoami/page/adapter/in/swagger/PageControllerSwagger.java
+++ b/src/main/java/com/dahhong/whoami/page/adapter/in/swagger/PageControllerSwagger.java
@@ -2,14 +2,19 @@ package com.dahhong.whoami.page.adapter.in.swagger;
 
 import com.dahhong.whoami.page.adapter.in.dto.PageRequestDto;
 import com.dahhong.whoami.page.domain.entity.Page;
+import com.dahhong.whoami.reply.adapter.in.dto.ReplyRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "페이지", description = "페이지 관련 CRUD API")
 public interface PageControllerSwagger {
@@ -44,4 +49,16 @@ public interface PageControllerSwagger {
 			@Parameter(name = "userId", description = "조회할 사용자의 ID", required = true)
 	})
 	ResponseEntity<?> getPageOfUser(String userId);
+
+	@Operation(summary = "특정 페이지에 답변 생성", description = "특정 페이지에 답변을 생성합니다.")
+	@Parameters({
+			@Parameter(name = "pageId", description = "답변을 추가할 페이지의 ID", required = true)
+	})
+	ResponseEntity<?> createReplyToPage(Long pageId, ReplyRequestDto replyRequest);
+
+	@Operation(summary = "특정 페이지의 답변 조회", description = "특정 페이지에 대한 모든 답변을 조회합니다.")
+	@Parameters({
+			@Parameter(name = "pageId", description = "답변을 조회할 페이지의 ID", required = true)
+	})
+	ResponseEntity<?> getRepliesOfPage(Long pageId);
 }

--- a/src/main/java/com/dahhong/whoami/page/domain/entity/Page.java
+++ b/src/main/java/com/dahhong/whoami/page/domain/entity/Page.java
@@ -16,7 +16,7 @@ public class Page extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@ManyToOne(fetch = FetchType.EAGER)
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
 

--- a/src/main/java/com/dahhong/whoami/reply/adapter/in/ReplyController.java
+++ b/src/main/java/com/dahhong/whoami/reply/adapter/in/ReplyController.java
@@ -1,6 +1,7 @@
 package com.dahhong.whoami.reply.adapter.in;
 
 import com.dahhong.whoami.global.response.ApiResponse;
+import com.dahhong.whoami.reply.adapter.in.dto.CreateReplyResponseDto;
 import com.dahhong.whoami.reply.adapter.in.dto.GetReplyResponseDto;
 import com.dahhong.whoami.reply.adapter.in.dto.ReplyRequestDto;
 import com.dahhong.whoami.reply.application.port.in.CreateReplyUseCase;
@@ -27,7 +28,7 @@ public class ReplyController {
 	@PostMapping("/{pageId}")
 	public ResponseEntity<?> createReply(@PathVariable Long pageId, @Valid @RequestBody ReplyRequestDto replyRequest) {
 		Reply createdReply = createReplyUseCase.createReply(pageId, replyRequest.getReplyUsername(), replyRequest.getContent());
-		return ResponseEntity.ok(ApiResponse.success(createdReply)); //CreateReplyResponseDto 굳이 필요할까요? 안 넣겠습니다.
+		return ResponseEntity.ok(ApiResponse.success(new CreateReplyResponseDto("성공적으로 답변을 생성하였습니다.", createdReply.getId())));
 	}
 
 	@GetMapping("/{pageId}")

--- a/src/main/java/com/dahhong/whoami/reply/adapter/in/ReplyController.java
+++ b/src/main/java/com/dahhong/whoami/reply/adapter/in/ReplyController.java
@@ -32,7 +32,7 @@ public class ReplyController implements ReplyControllerSwagger {
 
 	@GetMapping("/{pageId}")
 	public ResponseEntity<?> getReplyOfPage(@PathVariable Long pageId) {
-		List<GetReplyResponseDto> replies = getReplyUseCase.getRepliesOfPage(pageId).stream().map((reply)-> GetReplyResponseDto.of(reply)).toList();
+		List<GetReplyResponseDto> replies = getReplyUseCase.getRepliesOfPage(pageId).stream().map((reply)-> GetReplyResponseDto.of(reply, pageId)).toList();
 		return ResponseEntity.ok(ApiResponse.success(replies));
 	}
 

--- a/src/main/java/com/dahhong/whoami/reply/adapter/in/ReplyController.java
+++ b/src/main/java/com/dahhong/whoami/reply/adapter/in/ReplyController.java
@@ -4,10 +4,9 @@ import com.dahhong.whoami.global.response.ApiResponse;
 import com.dahhong.whoami.reply.adapter.in.dto.CreateReplyResponseDto;
 import com.dahhong.whoami.reply.adapter.in.dto.GetReplyResponseDto;
 import com.dahhong.whoami.reply.adapter.in.dto.ReplyRequestDto;
+import com.dahhong.whoami.reply.adapter.in.swagger.ReplyControllerSwagger;
 import com.dahhong.whoami.reply.application.port.in.CreateReplyUseCase;
-import com.dahhong.whoami.reply.application.port.in.DeleteReplyUseCase;
 import com.dahhong.whoami.reply.application.port.in.GetReplyUseCase;
-import com.dahhong.whoami.reply.application.port.in.UpdateReplyUseCase;
 import com.dahhong.whoami.reply.domain.entity.Reply;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +18,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/reply")
-public class ReplyController {
+public class ReplyController implements ReplyControllerSwagger {
 
 	private final CreateReplyUseCase createReplyUseCase;
 
@@ -38,7 +37,7 @@ public class ReplyController {
 	}
 
 	@GetMapping("/all")
-	public ResponseEntity<?> getAllReplys() {
+	public ResponseEntity<?> getAllReplies() {
 		List<GetReplyResponseDto> allReplies = getReplyUseCase.getAllReplies().stream().map((reply)-> GetReplyResponseDto.of(reply)).toList();
 		return ResponseEntity.ok(ApiResponse.success(allReplies));
 	}

--- a/src/main/java/com/dahhong/whoami/reply/adapter/in/ReplyController.java
+++ b/src/main/java/com/dahhong/whoami/reply/adapter/in/ReplyController.java
@@ -6,6 +6,7 @@ import com.dahhong.whoami.reply.adapter.in.dto.GetReplyResponseDto;
 import com.dahhong.whoami.reply.adapter.in.dto.ReplyRequestDto;
 import com.dahhong.whoami.reply.adapter.in.swagger.ReplyControllerSwagger;
 import com.dahhong.whoami.reply.application.port.in.CreateReplyUseCase;
+import com.dahhong.whoami.reply.application.port.in.DeleteReplyUseCase;
 import com.dahhong.whoami.reply.application.port.in.GetReplyUseCase;
 import com.dahhong.whoami.reply.domain.entity.Reply;
 import jakarta.validation.Valid;
@@ -20,26 +21,20 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/reply")
 public class ReplyController implements ReplyControllerSwagger {
-
-	private final CreateReplyUseCase createReplyUseCase;
-
 	private final GetReplyUseCase getReplyUseCase;
 
-	@PostMapping("/{pageId}")
-	public ResponseEntity<?> createReply(@Positive @PathVariable Long pageId, @Valid @RequestBody ReplyRequestDto replyRequest) {
-		Reply createdReply = createReplyUseCase.createReply(pageId, replyRequest.getReplyUsername(), replyRequest.getContent());
-		return ResponseEntity.ok(ApiResponse.success(new CreateReplyResponseDto("성공적으로 답변을 생성하였습니다.", createdReply.getId())));
-	}
-
-	@GetMapping("/{pageId}")
-	public ResponseEntity<?> getReplyOfPage(@Positive @PathVariable Long pageId) {
-		List<GetReplyResponseDto> replies = getReplyUseCase.getRepliesOfPage(pageId).stream().map((reply)-> GetReplyResponseDto.of(reply, pageId)).toList();
-		return ResponseEntity.ok(ApiResponse.success(replies));
-	}
+	private final DeleteReplyUseCase deleteReplyUseCase;
 
 	@GetMapping("/all")
 	public ResponseEntity<?> getAllReplies() {
 		List<GetReplyResponseDto> allReplies = getReplyUseCase.getAllReplies().stream().map((reply)-> GetReplyResponseDto.of(reply)).toList();
 		return ResponseEntity.ok(ApiResponse.success(allReplies));
+	}
+
+	@DeleteMapping("/{replyId}")
+	public ResponseEntity<?> deleteReply(@Positive @PathVariable Long replyId) {
+		//Security Filter에서 Admin 여부가 확인됨
+		deleteReplyUseCase.deleteReply(replyId);
+		return ResponseEntity.ok(ApiResponse.success());
 	}
 }

--- a/src/main/java/com/dahhong/whoami/reply/adapter/in/ReplyController.java
+++ b/src/main/java/com/dahhong/whoami/reply/adapter/in/ReplyController.java
@@ -1,0 +1,46 @@
+package com.dahhong.whoami.reply.adapter.in;
+
+import com.dahhong.whoami.reply.adapter.in.dto.ReplyRequestDto;
+import com.dahhong.whoami.reply.application.port.in.CreateReplyUseCase;
+import com.dahhong.whoami.reply.application.port.in.DeleteReplyUseCase;
+import com.dahhong.whoami.reply.application.port.in.GetReplyUseCase;
+import com.dahhong.whoami.reply.application.port.in.UpdateReplyUseCase;
+import com.dahhong.whoami.reply.domain.entity.Reply;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/reply")
+public class ReplyController {
+
+	//private final CreateReplyUseCase createReplyUseCase;
+
+	//private final GetReplyUseCase getReplyUseCase;
+
+	@PostMapping("/create")
+	public ResponseEntity<?> createReply(@Valid @RequestBody ReplyRequestDto replyRequest) {
+		/**
+		 * TODO : createReplyUseCase.save()
+		 */
+		return null;
+	}
+
+	@GetMapping("/{pageId}")
+	public ResponseEntity<?> getReplyOfPage(@PathVariable int pageId) {
+		/**
+		 * TODO : getReplyUseCase.getReplyOfPage()
+		 */
+		return null;
+	}
+
+	@GetMapping("/all")
+	public ResponseEntity<?> getAllReplys() {
+		/**
+		 * TODO : getReplyUseCase.getAllReplies()
+		 */
+		return null;
+	}
+}

--- a/src/main/java/com/dahhong/whoami/reply/adapter/in/ReplyController.java
+++ b/src/main/java/com/dahhong/whoami/reply/adapter/in/ReplyController.java
@@ -9,6 +9,7 @@ import com.dahhong.whoami.reply.application.port.in.CreateReplyUseCase;
 import com.dahhong.whoami.reply.application.port.in.GetReplyUseCase;
 import com.dahhong.whoami.reply.domain.entity.Reply;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -25,13 +26,13 @@ public class ReplyController implements ReplyControllerSwagger {
 	private final GetReplyUseCase getReplyUseCase;
 
 	@PostMapping("/{pageId}")
-	public ResponseEntity<?> createReply(@PathVariable Long pageId, @Valid @RequestBody ReplyRequestDto replyRequest) {
+	public ResponseEntity<?> createReply(@Positive @PathVariable Long pageId, @Valid @RequestBody ReplyRequestDto replyRequest) {
 		Reply createdReply = createReplyUseCase.createReply(pageId, replyRequest.getReplyUsername(), replyRequest.getContent());
 		return ResponseEntity.ok(ApiResponse.success(new CreateReplyResponseDto("성공적으로 답변을 생성하였습니다.", createdReply.getId())));
 	}
 
 	@GetMapping("/{pageId}")
-	public ResponseEntity<?> getReplyOfPage(@PathVariable Long pageId) {
+	public ResponseEntity<?> getReplyOfPage(@Positive @PathVariable Long pageId) {
 		List<GetReplyResponseDto> replies = getReplyUseCase.getRepliesOfPage(pageId).stream().map((reply)-> GetReplyResponseDto.of(reply, pageId)).toList();
 		return ResponseEntity.ok(ApiResponse.success(replies));
 	}

--- a/src/main/java/com/dahhong/whoami/reply/adapter/in/ReplyController.java
+++ b/src/main/java/com/dahhong/whoami/reply/adapter/in/ReplyController.java
@@ -1,5 +1,7 @@
 package com.dahhong.whoami.reply.adapter.in;
 
+import com.dahhong.whoami.global.response.ApiResponse;
+import com.dahhong.whoami.reply.adapter.in.dto.GetReplyResponseDto;
 import com.dahhong.whoami.reply.adapter.in.dto.ReplyRequestDto;
 import com.dahhong.whoami.reply.application.port.in.CreateReplyUseCase;
 import com.dahhong.whoami.reply.application.port.in.DeleteReplyUseCase;
@@ -11,36 +13,32 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/reply")
 public class ReplyController {
 
-	//private final CreateReplyUseCase createReplyUseCase;
+	private final CreateReplyUseCase createReplyUseCase;
 
-	//private final GetReplyUseCase getReplyUseCase;
+	private final GetReplyUseCase getReplyUseCase;
 
-	@PostMapping("/create")
-	public ResponseEntity<?> createReply(@Valid @RequestBody ReplyRequestDto replyRequest) {
-		/**
-		 * TODO : createReplyUseCase.save()
-		 */
-		return null;
+	@PostMapping("/{pageId}")
+	public ResponseEntity<?> createReply(@PathVariable Long pageId, @Valid @RequestBody ReplyRequestDto replyRequest) {
+		Reply createdReply = createReplyUseCase.createReply(pageId, replyRequest.getReplyUsername(), replyRequest.getContent());
+		return ResponseEntity.ok(ApiResponse.success(createdReply)); //CreateReplyResponseDto 굳이 필요할까요? 안 넣겠습니다.
 	}
 
 	@GetMapping("/{pageId}")
-	public ResponseEntity<?> getReplyOfPage(@PathVariable int pageId) {
-		/**
-		 * TODO : getReplyUseCase.getReplyOfPage()
-		 */
-		return null;
+	public ResponseEntity<?> getReplyOfPage(@PathVariable Long pageId) {
+		List<GetReplyResponseDto> replies = getReplyUseCase.getRepliesOfPage(pageId).stream().map((reply)-> GetReplyResponseDto.of(reply)).toList();
+		return ResponseEntity.ok(ApiResponse.success(replies));
 	}
 
 	@GetMapping("/all")
 	public ResponseEntity<?> getAllReplys() {
-		/**
-		 * TODO : getReplyUseCase.getAllReplies()
-		 */
-		return null;
+		List<GetReplyResponseDto> allReplies = getReplyUseCase.getAllReplies().stream().map((reply)-> GetReplyResponseDto.of(reply)).toList();
+		return ResponseEntity.ok(ApiResponse.success(allReplies));
 	}
 }

--- a/src/main/java/com/dahhong/whoami/reply/adapter/in/dto/CreateReplyResponseDto.java
+++ b/src/main/java/com/dahhong/whoami/reply/adapter/in/dto/CreateReplyResponseDto.java
@@ -1,0 +1,13 @@
+package com.dahhong.whoami.reply.adapter.in.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class CreateReplyResponseDto {
+	private final String message;
+	private final Long id;
+}

--- a/src/main/java/com/dahhong/whoami/reply/adapter/in/dto/GetReplyResponseDto.java
+++ b/src/main/java/com/dahhong/whoami/reply/adapter/in/dto/GetReplyResponseDto.java
@@ -13,6 +13,7 @@ public class GetReplyResponseDto {
 	private Long id;
 	private String username;
 	private String content;
+	private Long pageId;
 	private LocalDateTime createdDate;
 	private LocalDateTime modifiedDate;
 
@@ -21,6 +22,18 @@ public class GetReplyResponseDto {
 				reply.getId(),
 				reply.getReplyUsername(),
 				reply.getContent(),
+				reply.getPage().getId(),
+				reply.getCreatedDate(),
+				reply.getModifiedDate()
+		);
+	}
+
+	public static GetReplyResponseDto of(Reply reply, Long pageId) {
+		return new GetReplyResponseDto(
+				reply.getId(),
+				reply.getReplyUsername(),
+				reply.getContent(),
+				pageId,
 				reply.getCreatedDate(),
 				reply.getModifiedDate()
 		);

--- a/src/main/java/com/dahhong/whoami/reply/adapter/in/dto/GetReplyResponseDto.java
+++ b/src/main/java/com/dahhong/whoami/reply/adapter/in/dto/GetReplyResponseDto.java
@@ -1,0 +1,28 @@
+package com.dahhong.whoami.reply.adapter.in.dto;
+
+import com.dahhong.whoami.reply.domain.entity.Reply;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@Getter
+@Setter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetReplyResponseDto {
+	private Long id;
+	private String username;
+	private String content;
+	private LocalDateTime createdDate;
+	private LocalDateTime modifiedDate;
+
+	public static GetReplyResponseDto of(Reply reply) {
+		return new GetReplyResponseDto(
+				reply.getId(),
+				reply.getReplyUsername(),
+				reply.getContent(),
+				reply.getCreatedDate(),
+				reply.getModifiedDate()
+		);
+	}
+}

--- a/src/main/java/com/dahhong/whoami/reply/adapter/in/dto/ReplyRequestDto.java
+++ b/src/main/java/com/dahhong/whoami/reply/adapter/in/dto/ReplyRequestDto.java
@@ -1,0 +1,17 @@
+package com.dahhong.whoami.reply.adapter.in.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class ReplyRequestDto {
+	@NotBlank(message = "Username of reply is required")
+	private String replyUsername;
+
+	@NotBlank(message = "content is required")
+	private String content;
+}

--- a/src/main/java/com/dahhong/whoami/reply/adapter/in/swagger/ReplyControllerSwagger.java
+++ b/src/main/java/com/dahhong/whoami/reply/adapter/in/swagger/ReplyControllerSwagger.java
@@ -1,35 +1,21 @@
 package com.dahhong.whoami.reply.adapter.in.swagger;
 
-import com.dahhong.whoami.global.response.ApiResponse;
-import com.dahhong.whoami.reply.adapter.in.dto.CreateReplyResponseDto;
-import com.dahhong.whoami.reply.adapter.in.dto.GetReplyResponseDto;
 import com.dahhong.whoami.reply.adapter.in.dto.ReplyRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
-import java.util.List;
-
 @Tag(name = "답변", description = "답변 관련 API")
 public interface ReplyControllerSwagger {
-
-	@Operation(summary = "답변 생성", description = "특정 페이지에 답변을 생성합니다.")
-	@Parameters({
-			@Parameter(name = "pageId", description = "답변을 추가할 페이지의 ID", required = true)
-	})
-	ResponseEntity<?> createReply(@PathVariable Long pageId, @RequestBody @Valid ReplyRequestDto replyRequest);
-
-	@Operation(summary = "특정 페이지의 답변 조회", description = "특정 페이지에 대한 모든 답변을 조회합니다.")
-	@Parameters({
-			@Parameter(name = "pageId", description = "답변을 조회할 페이지의 ID", required = true)
-	})
-	ResponseEntity<?> getReplyOfPage(@PathVariable Long pageId);
-
 	@Operation(summary = "모든 답변 조회", description = "모든 답변을 조회합니다.")
 	ResponseEntity<?> getAllReplies();
+
+	@Operation(summary = "특정 답변 삭제", description = "특정 답변을 삭제합니다.")
+	ResponseEntity<?> deleteReply(@Positive @PathVariable Long replyId);
 }

--- a/src/main/java/com/dahhong/whoami/reply/adapter/in/swagger/ReplyControllerSwagger.java
+++ b/src/main/java/com/dahhong/whoami/reply/adapter/in/swagger/ReplyControllerSwagger.java
@@ -1,0 +1,35 @@
+package com.dahhong.whoami.reply.adapter.in.swagger;
+
+import com.dahhong.whoami.global.response.ApiResponse;
+import com.dahhong.whoami.reply.adapter.in.dto.CreateReplyResponseDto;
+import com.dahhong.whoami.reply.adapter.in.dto.GetReplyResponseDto;
+import com.dahhong.whoami.reply.adapter.in.dto.ReplyRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@Tag(name = "답변", description = "답변 관련 API")
+public interface ReplyControllerSwagger {
+
+	@Operation(summary = "답변 생성", description = "특정 페이지에 답변을 생성합니다.")
+	@Parameters({
+			@Parameter(name = "pageId", description = "답변을 추가할 페이지의 ID", required = true)
+	})
+	ResponseEntity<?> createReply(@PathVariable Long pageId, @RequestBody @Valid ReplyRequestDto replyRequest);
+
+	@Operation(summary = "특정 페이지의 답변 조회", description = "특정 페이지에 대한 모든 답변을 조회합니다.")
+	@Parameters({
+			@Parameter(name = "pageId", description = "답변을 조회할 페이지의 ID", required = true)
+	})
+	ResponseEntity<?> getReplyOfPage(@PathVariable Long pageId);
+
+	@Operation(summary = "모든 답변 조회", description = "모든 답변을 조회합니다.")
+	ResponseEntity<?> getAllReplies();
+}

--- a/src/main/java/com/dahhong/whoami/reply/adapter/out/ReplyCommandAdapter.java
+++ b/src/main/java/com/dahhong/whoami/reply/adapter/out/ReplyCommandAdapter.java
@@ -15,4 +15,9 @@ public class ReplyCommandAdapter implements ReplyCommandPort {
 	public Reply save(Reply reply) {
 		return replyRepository.save(reply);
 	}
+
+	@Override
+	public void delete(Reply reply) {
+		replyRepository.delete(reply);
+	}
 }

--- a/src/main/java/com/dahhong/whoami/reply/adapter/out/ReplyCommandAdapter.java
+++ b/src/main/java/com/dahhong/whoami/reply/adapter/out/ReplyCommandAdapter.java
@@ -1,0 +1,18 @@
+package com.dahhong.whoami.reply.adapter.out;
+
+import com.dahhong.whoami.reply.application.port.out.ReplyCommandPort;
+import com.dahhong.whoami.reply.domain.entity.Reply;
+import com.dahhong.whoami.reply.infrastructure.repository.ReplyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReplyCommandAdapter implements ReplyCommandPort {
+	private final ReplyRepository replyRepository;
+
+	@Override
+	public Reply save(Reply reply) {
+		return replyRepository.save(reply);
+	}
+}

--- a/src/main/java/com/dahhong/whoami/reply/adapter/out/ReplyQueryAdapter.java
+++ b/src/main/java/com/dahhong/whoami/reply/adapter/out/ReplyQueryAdapter.java
@@ -1,0 +1,26 @@
+package com.dahhong.whoami.reply.adapter.out;
+
+import com.dahhong.whoami.reply.application.port.out.ReplyQueryPort;
+import com.dahhong.whoami.reply.domain.entity.Reply;
+import com.dahhong.whoami.reply.infrastructure.repository.ReplyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ReplyQueryAdapter implements ReplyQueryPort {
+
+	private final ReplyRepository replyRepository;
+
+	@Override
+	public List<Reply> findAllFetchJoin() {
+		return replyRepository.findAllJoinFetch();
+	}
+
+	@Override
+	public List<Reply> findByPageIdFetchJoin(Long pageId) {
+		return replyRepository.findByPageIdFetchJoin(pageId);
+	}
+}

--- a/src/main/java/com/dahhong/whoami/reply/adapter/out/ReplyQueryAdapter.java
+++ b/src/main/java/com/dahhong/whoami/reply/adapter/out/ReplyQueryAdapter.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -22,5 +23,10 @@ public class ReplyQueryAdapter implements ReplyQueryPort {
 	@Override
 	public List<Reply> findByPageIdFetchJoin(Long pageId) {
 		return replyRepository.findByPageIdFetchJoin(pageId);
+	}
+
+	@Override
+	public Optional<Reply> findById(Long id) {
+		return replyRepository.findById(id);
 	}
 }

--- a/src/main/java/com/dahhong/whoami/reply/application/port/in/CreateReplyUseCase.java
+++ b/src/main/java/com/dahhong/whoami/reply/application/port/in/CreateReplyUseCase.java
@@ -3,5 +3,5 @@ package com.dahhong.whoami.reply.application.port.in;
 import com.dahhong.whoami.reply.domain.entity.Reply;
 
 public interface CreateReplyUseCase {
-	Reply createReply(String replyUserId, String content);
+	Reply createReply(Long pageId, String replyUsername, String content);
 }

--- a/src/main/java/com/dahhong/whoami/reply/application/port/in/CreateReplyUseCase.java
+++ b/src/main/java/com/dahhong/whoami/reply/application/port/in/CreateReplyUseCase.java
@@ -1,0 +1,7 @@
+package com.dahhong.whoami.reply.application.port.in;
+
+import com.dahhong.whoami.reply.domain.entity.Reply;
+
+public interface CreateReplyUseCase {
+	Reply createReply(String replyUserId, String content);
+}

--- a/src/main/java/com/dahhong/whoami/reply/application/port/in/DeleteReplyUseCase.java
+++ b/src/main/java/com/dahhong/whoami/reply/application/port/in/DeleteReplyUseCase.java
@@ -1,0 +1,7 @@
+package com.dahhong.whoami.reply.application.port.in;
+
+public interface DeleteReplyUseCase {
+	/**
+	 * Reply를 삭제한다? 그런건 없어요~
+	 */
+}

--- a/src/main/java/com/dahhong/whoami/reply/application/port/in/DeleteReplyUseCase.java
+++ b/src/main/java/com/dahhong/whoami/reply/application/port/in/DeleteReplyUseCase.java
@@ -1,7 +1,7 @@
 package com.dahhong.whoami.reply.application.port.in;
 
+import com.dahhong.whoami.reply.domain.entity.Reply;
+
 public interface DeleteReplyUseCase {
-	/**
-	 * Reply를 삭제한다? 그런건 없어요~
-	 */
+	public void deleteReply(Long id);
 }

--- a/src/main/java/com/dahhong/whoami/reply/application/port/in/GetReplyUseCase.java
+++ b/src/main/java/com/dahhong/whoami/reply/application/port/in/GetReplyUseCase.java
@@ -3,9 +3,12 @@ package com.dahhong.whoami.reply.application.port.in;
 import com.dahhong.whoami.reply.domain.entity.Reply;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface GetReplyUseCase {
 	List<Reply> getAllReplies();
 
 	List<Reply> getRepliesOfPage(Long pageId);
+
+	Reply getReplyById(Long id);
 }

--- a/src/main/java/com/dahhong/whoami/reply/application/port/in/GetReplyUseCase.java
+++ b/src/main/java/com/dahhong/whoami/reply/application/port/in/GetReplyUseCase.java
@@ -1,0 +1,7 @@
+package com.dahhong.whoami.reply.application.port.in;
+
+import com.dahhong.whoami.reply.domain.entity.Reply;
+
+public interface GetReplyUseCase {
+	Reply getReplyOfPage(Long pageId);
+}

--- a/src/main/java/com/dahhong/whoami/reply/application/port/in/GetReplyUseCase.java
+++ b/src/main/java/com/dahhong/whoami/reply/application/port/in/GetReplyUseCase.java
@@ -2,6 +2,10 @@ package com.dahhong.whoami.reply.application.port.in;
 
 import com.dahhong.whoami.reply.domain.entity.Reply;
 
+import java.util.List;
+
 public interface GetReplyUseCase {
-	Reply getReplyOfPage(Long pageId);
+	List<Reply> getAllReplies();
+
+	List<Reply> getRepliesOfPage(Long pageId);
 }

--- a/src/main/java/com/dahhong/whoami/reply/application/port/in/UpdateReplyUseCase.java
+++ b/src/main/java/com/dahhong/whoami/reply/application/port/in/UpdateReplyUseCase.java
@@ -1,0 +1,7 @@
+package com.dahhong.whoami.reply.application.port.in;
+
+public interface UpdateReplyUseCase {
+	/**
+	 * Reply를 수정한다? 그런건 없어요~
+	 */
+}

--- a/src/main/java/com/dahhong/whoami/reply/application/port/out/ReplyCommandPort.java
+++ b/src/main/java/com/dahhong/whoami/reply/application/port/out/ReplyCommandPort.java
@@ -4,4 +4,6 @@ import com.dahhong.whoami.reply.domain.entity.Reply;
 
 public interface ReplyCommandPort {
 	Reply save (Reply reply);
+
+	void delete (Reply reply);
 }

--- a/src/main/java/com/dahhong/whoami/reply/application/port/out/ReplyCommandPort.java
+++ b/src/main/java/com/dahhong/whoami/reply/application/port/out/ReplyCommandPort.java
@@ -1,0 +1,7 @@
+package com.dahhong.whoami.reply.application.port.out;
+
+import com.dahhong.whoami.reply.domain.entity.Reply;
+
+public interface ReplyCommandPort {
+	Reply save (Reply reply);
+}

--- a/src/main/java/com/dahhong/whoami/reply/application/port/out/ReplyQueryPort.java
+++ b/src/main/java/com/dahhong/whoami/reply/application/port/out/ReplyQueryPort.java
@@ -3,9 +3,12 @@ package com.dahhong.whoami.reply.application.port.out;
 import com.dahhong.whoami.reply.domain.entity.Reply;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ReplyQueryPort {
 	List<Reply> findAllFetchJoin();
 
 	List<Reply> findByPageIdFetchJoin(Long pageId);
+
+	Optional<Reply> findById(Long id);
 }

--- a/src/main/java/com/dahhong/whoami/reply/application/port/out/ReplyQueryPort.java
+++ b/src/main/java/com/dahhong/whoami/reply/application/port/out/ReplyQueryPort.java
@@ -1,0 +1,11 @@
+package com.dahhong.whoami.reply.application.port.out;
+
+import com.dahhong.whoami.reply.domain.entity.Reply;
+
+import java.util.List;
+
+public interface ReplyQueryPort {
+	List<Reply> findAllFetchJoin();
+
+	List<Reply> findByPageIdFetchJoin(Long pageId);
+}

--- a/src/main/java/com/dahhong/whoami/reply/application/service/CreateReplyService.java
+++ b/src/main/java/com/dahhong/whoami/reply/application/service/CreateReplyService.java
@@ -1,0 +1,24 @@
+package com.dahhong.whoami.reply.application.service;
+
+import com.dahhong.whoami.page.application.port.in.GetPageUseCase;
+import com.dahhong.whoami.page.domain.entity.Page;
+import com.dahhong.whoami.reply.application.port.in.CreateReplyUseCase;
+import com.dahhong.whoami.reply.application.port.out.ReplyCommandPort;
+import com.dahhong.whoami.reply.domain.entity.Reply;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CreateReplyService implements CreateReplyUseCase {
+	private final ReplyCommandPort replyCommandPort;
+
+	private final GetPageUseCase getPageUseCase;
+
+	@Override
+	public Reply createReply(Long pageId, String replyUsername, String content) {
+		Page page = getPageUseCase.getPage(pageId);
+		Reply reply = Reply.of(null, replyUsername, page, content);
+		return replyCommandPort.save(reply);
+	}
+}

--- a/src/main/java/com/dahhong/whoami/reply/application/service/DeleteReplyService.java
+++ b/src/main/java/com/dahhong/whoami/reply/application/service/DeleteReplyService.java
@@ -1,0 +1,24 @@
+package com.dahhong.whoami.reply.application.service;
+
+import com.dahhong.whoami.reply.application.port.in.DeleteReplyUseCase;
+import com.dahhong.whoami.reply.application.port.in.GetReplyUseCase;
+import com.dahhong.whoami.reply.application.port.out.ReplyCommandPort;
+import com.dahhong.whoami.reply.domain.entity.Reply;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteReplyService implements DeleteReplyUseCase {
+	private final ReplyCommandPort replyCommandPort;
+
+	private final GetReplyUseCase getReplyUseCase;
+
+	@Override
+	@Transactional
+	public void deleteReply(Long id) {
+		Reply reply = getReplyUseCase.getReplyById(id);
+		replyCommandPort.delete(reply);
+	}
+}

--- a/src/main/java/com/dahhong/whoami/reply/application/service/GetReplyService.java
+++ b/src/main/java/com/dahhong/whoami/reply/application/service/GetReplyService.java
@@ -14,6 +14,8 @@ import java.util.List;
 public class GetReplyService implements GetReplyUseCase {
 	private final ReplyQueryPort replyQueryPort;
 
+	private final GetPageUseCase getPageUseCase;
+
 	@Override
 	public List<Reply> getAllReplies() {
 		return replyQueryPort.findAllFetchJoin();
@@ -21,6 +23,7 @@ public class GetReplyService implements GetReplyUseCase {
 
 	@Override
 	public List<Reply> getRepliesOfPage(Long pageId) {
+		getPageUseCase.getPage(pageId); //TODO: Page가 없으면 404에러 띄우려고 넣은 줄인데, 더 좋은 방법이 없을깝쇼?
 		return replyQueryPort.findByPageIdFetchJoin(pageId);
 	}
 }

--- a/src/main/java/com/dahhong/whoami/reply/application/service/GetReplyService.java
+++ b/src/main/java/com/dahhong/whoami/reply/application/service/GetReplyService.java
@@ -1,5 +1,6 @@
 package com.dahhong.whoami.reply.application.service;
 
+import com.dahhong.whoami.global.exception.customException.NotFoundException;
 import com.dahhong.whoami.page.application.port.in.GetPageUseCase;
 import com.dahhong.whoami.reply.application.port.in.GetReplyUseCase;
 import com.dahhong.whoami.reply.application.port.out.ReplyQueryPort;
@@ -24,5 +25,10 @@ public class GetReplyService implements GetReplyUseCase {
 	@Override
 	public List<Reply> getRepliesOfPage(Long pageId) {
 		return replyQueryPort.findByPageIdFetchJoin(pageId);
+	}
+
+	@Override
+	public Reply getReplyById(Long id) {
+		return replyQueryPort.findById(id).orElseThrow(()-> new NotFoundException("해당 답변을 찾을 수 없습니다."));
 	}
 }

--- a/src/main/java/com/dahhong/whoami/reply/application/service/GetReplyService.java
+++ b/src/main/java/com/dahhong/whoami/reply/application/service/GetReplyService.java
@@ -1,0 +1,26 @@
+package com.dahhong.whoami.reply.application.service;
+
+import com.dahhong.whoami.page.application.port.in.GetPageUseCase;
+import com.dahhong.whoami.reply.application.port.in.GetReplyUseCase;
+import com.dahhong.whoami.reply.application.port.out.ReplyQueryPort;
+import com.dahhong.whoami.reply.domain.entity.Reply;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GetReplyService implements GetReplyUseCase {
+	private final ReplyQueryPort replyQueryPort;
+
+	@Override
+	public List<Reply> getAllReplies() {
+		return replyQueryPort.findAllFetchJoin();
+	}
+
+	@Override
+	public List<Reply> getRepliesOfPage(Long pageId) {
+		return replyQueryPort.findByPageIdFetchJoin(pageId);
+	}
+}

--- a/src/main/java/com/dahhong/whoami/reply/application/service/GetReplyService.java
+++ b/src/main/java/com/dahhong/whoami/reply/application/service/GetReplyService.java
@@ -23,7 +23,6 @@ public class GetReplyService implements GetReplyUseCase {
 
 	@Override
 	public List<Reply> getRepliesOfPage(Long pageId) {
-		getPageUseCase.getPage(pageId); //TODO: Page가 없으면 404에러 띄우려고 넣은 줄인데, 더 좋은 방법이 없을깝쇼?
 		return replyQueryPort.findByPageIdFetchJoin(pageId);
 	}
 }

--- a/src/main/java/com/dahhong/whoami/reply/domain/entity/Reply.java
+++ b/src/main/java/com/dahhong/whoami/reply/domain/entity/Reply.java
@@ -16,6 +16,9 @@ public class Reply extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Column(nullable = false, length = 100)
+	private String replyUsername;
+
 	@ManyToOne(fetch=FetchType.EAGER)
 	@JoinColumn(name = "page_id")
 	private Page page;

--- a/src/main/java/com/dahhong/whoami/reply/domain/entity/Reply.java
+++ b/src/main/java/com/dahhong/whoami/reply/domain/entity/Reply.java
@@ -1,0 +1,25 @@
+package com.dahhong.whoami.reply.domain.entity;
+
+import com.dahhong.whoami.global.auditing.BaseTimeEntity;
+import com.dahhong.whoami.page.domain.entity.Page;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@Table(name = "wai_reply")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Reply extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch=FetchType.EAGER)
+	@JoinColumn(name = "page_id")
+	private Page page;
+
+	@Column(length = 500)
+	private String content;
+}

--- a/src/main/java/com/dahhong/whoami/reply/domain/entity/Reply.java
+++ b/src/main/java/com/dahhong/whoami/reply/domain/entity/Reply.java
@@ -19,7 +19,7 @@ public class Reply extends BaseTimeEntity {
 	@Column(nullable = false, length = 100)
 	private String replyUsername;
 
-	@ManyToOne(fetch=FetchType.EAGER)
+	@ManyToOne(fetch=FetchType.LAZY)
 	@JoinColumn(name = "page_id")
 	private Page page;
 

--- a/src/main/java/com/dahhong/whoami/reply/domain/entity/Reply.java
+++ b/src/main/java/com/dahhong/whoami/reply/domain/entity/Reply.java
@@ -25,4 +25,8 @@ public class Reply extends BaseTimeEntity {
 
 	@Column(length = 500)
 	private String content;
+
+	public static Reply of(Long id, String replyUsername, Page page, String content) {
+		return new Reply(id, replyUsername, page, content);
+	}
 }

--- a/src/main/java/com/dahhong/whoami/reply/infrastructure/repository/ReplyRepository.java
+++ b/src/main/java/com/dahhong/whoami/reply/infrastructure/repository/ReplyRepository.java
@@ -1,0 +1,13 @@
+package com.dahhong.whoami.reply.infrastructure.repository;
+
+import com.dahhong.whoami.reply.domain.entity.Reply;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface ReplyRepository extends JpaRepository<Reply, Long> {
+
+	@Query("select r from Reply r join fetch r.page ")
+	List<Reply> findAllJoinFetch();
+}

--- a/src/main/java/com/dahhong/whoami/reply/infrastructure/repository/ReplyRepository.java
+++ b/src/main/java/com/dahhong/whoami/reply/infrastructure/repository/ReplyRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
 
-	@Query("select r from Reply r join fetch r.page ")
+	@Query("select r from Reply r join fetch r.page p")
 	List<Reply> findAllJoinFetch();
 
 	@Query("select r from Reply r join fetch r.page p where p.id = :pageId")

--- a/src/main/java/com/dahhong/whoami/reply/infrastructure/repository/ReplyRepository.java
+++ b/src/main/java/com/dahhong/whoami/reply/infrastructure/repository/ReplyRepository.java
@@ -13,5 +13,5 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
 	List<Reply> findAllJoinFetch();
 
 	@Query("select r from Reply r join fetch r.page p where p.id = :pageId")
-	List<Reply> findByPageId(Long pageId);
+	List<Reply> findByPageIdFetchJoin(Long pageId);
 }

--- a/src/main/java/com/dahhong/whoami/reply/infrastructure/repository/ReplyRepository.java
+++ b/src/main/java/com/dahhong/whoami/reply/infrastructure/repository/ReplyRepository.java
@@ -3,6 +3,7 @@ package com.dahhong.whoami.reply.infrastructure.repository;
 import com.dahhong.whoami.reply.domain.entity.Reply;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -10,4 +11,7 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
 
 	@Query("select r from Reply r join fetch r.page ")
 	List<Reply> findAllJoinFetch();
+
+	@Query("select r from Reply r join fetch r.page p where p.id = :pageId")
+	List<Reply> findByPageId(Long pageId);
 }


### PR DESCRIPTION
### 유저(로그인 된)가 생성한 page에 익명의 reply를 작성할 수 있습니다. (reply는 로그인 불필요)  

- 티스토리 댓글달듯이, 각 reply에 닉네임을 임의로 설정  
- 수정,삭제 없이(편지를 한 번 보내면 수정/삭제가 안 되는 것처럼) 하자는 요구사항이 있었음.. 그래서 create과 read만 있고, UD는 없음.
- 비슷한 맥락에서, 이름만 적고 비번은 따로 받지 않음. 또한 replyUser 테이블(기존 ERD에 있던)도 불필요해짐

GET : 모든 답변 조회, 특정 페이지에 대한 답변 조회
POST : 특정 페이지에 답변 생성

이 세 가지 기능만 있고, Swagger에 문서화되어있슴니다

p.s. security filter chain에서 `.authenticated()`이슈 아직 안 봐주셨나요? 난 정말 모르겠음 ㅜㅜ