### PR TITLE
[Fix]: Authentication Provider Supports method가 항상 false를 리턴하는  버그 수정

### DIFF
--- a/src/main/java/com/dahhong/whoami/global/security/authenticationProvider/KakaoAuthenticationProvider.java
+++ b/src/main/java/com/dahhong/whoami/global/security/authenticationProvider/KakaoAuthenticationProvider.java
@@ -1,5 +1,6 @@
 package com.dahhong.whoami.global.security.authenticationProvider;
 
+import com.dahhong.whoami.global.security.filter.UserAuthentication;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -20,12 +21,13 @@ public class KakaoAuthenticationProvider implements AuthenticationProvider {
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
         UserDetails userDetails = userDetailsService.loadUserByUsername((String) authentication.getPrincipal());
-        return new UsernamePasswordAuthenticationToken(userDetails.getUsername(), userDetails.getPassword());
+        return new UserAuthentication(userDetails.getUsername(), userDetails.getPassword(), userDetails.getAuthorities());
     }
 
     @Override
     public boolean supports(Class<?> authentication) {
-        return false;
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication)
+                || UserAuthentication.class.isAssignableFrom(authentication);
     }
 
 }

--- a/src/main/java/com/dahhong/whoami/global/security/filter/KakaoJwtAuthenticationFilter.java
+++ b/src/main/java/com/dahhong/whoami/global/security/filter/KakaoJwtAuthenticationFilter.java
@@ -13,9 +13,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClientException;
@@ -79,7 +77,7 @@ public class KakaoJwtAuthenticationFilter extends GenericFilterBean {
         String userId = extractUserId(accessToken);
         if (verification(userId)) {
             try {
-                authenticate = kakaoAuthenticationProvider.authenticate(new UsernamePasswordAuthenticationToken(userId, ""));
+                authenticate = kakaoAuthenticationProvider.authenticate(new UserAuthentication(userId, "", null));
                 SecurityContextHolder.getContext().setAuthentication(authenticate);
             } catch(Exception e) {
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);

--- a/src/main/java/com/dahhong/whoami/global/security/filter/UserAuthentication.java
+++ b/src/main/java/com/dahhong/whoami/global/security/filter/UserAuthentication.java
@@ -1,0 +1,14 @@
+package com.dahhong.whoami.global.security.filter;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class UserAuthentication extends UsernamePasswordAuthenticationToken {
+
+    public UserAuthentication(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+        super(principal, credentials, authorities);
+    }
+
+}

--- a/src/main/java/com/dahhong/whoami/user/domain/entity/Role.java
+++ b/src/main/java/com/dahhong/whoami/user/domain/entity/Role.java
@@ -7,7 +7,7 @@ public enum Role implements GrantedAuthority {
 
     @Override
     public String getAuthority() {
-        return name();
+        return "ROLE_" + name();
     }
 
 }


### PR DESCRIPTION
## 변경
- UsernamePasswordAuthenticationToken을 상속받아 구현하는 UserAuthentication 객체 추가
- Spring Security Context에 Authorities가 추가되지 않고 있던 버그 수정